### PR TITLE
Fix blog

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name paf)
  (public_name paf)
- (libraries ke httpaf tuyau-tls tuyau-mirage tuyau-mirage.tcp tuyau-mirage.tls))
+ (libraries mirage-time ke httpaf tuyau-tls tuyau-mirage tuyau-mirage.tcp tuyau-mirage.tls))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name paf)
  (public_name paf)
- (libraries ke httpaf tuyau.mirage tuyau.mirage.tcp tuyau.mirage.tls))
+ (libraries ke httpaf tuyau-tls tuyau-mirage tuyau-mirage.tcp tuyau-mirage.tls))

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -191,10 +191,10 @@ module Httpaf
     connection_handler
 end
 
-module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) = struct
+module Make (StackV4 : Mirage_stack.V4) = struct
   open Lwt.Infix
 
-  module TCP = Tuyau_mirage_tcp.Make(Time)(StackV4)
+  module TCP = Tuyau_mirage_tcp.Make(StackV4)
 
   let tls_endpoint, tls_protocol = Tuyau_mirage_tls.protocol_with_tls ~key:TCP.endpoint TCP.protocol
   let tls_configuration, tls_service = Tuyau_mirage_tls.service_with_tls ~key:TCP.configuration TCP.service tls_protocol

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -151,8 +151,13 @@ module Httpaf
         let rec go () = match Server_connection.next_write_operation connection with
           | `Write iovecs ->
             Log.debug (fun m -> m "[`write]");
-            send flow iovecs >>= fun len ->
-            Server_connection.report_write_result connection len ;
+            send flow iovecs >>= fun res ->
+            Log.debug (fun m ->
+                let pp_res ppf = function
+                  | `Ok len -> Fmt.pf ppf "(`Ok %d byte(s))" len
+                  | `Closed -> Fmt.pf ppf "`Closed" in
+                m "[`write] write %a" pp_res res) ;
+            Server_connection.report_write_result connection res ;
             go ()
           | `Yield ->
             Log.debug (fun m -> m "[write:`yield]") ;

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -26,7 +26,8 @@ module Httpaf
     ; rd : Cstruct.t
     ; queue : (char, Bigarray.int8_unsigned_elt) Ke.t
     ; mutable rd_closed : bool
-    ; mutable wr_closed : bool }
+    ; mutable wr_closed : bool
+    ; mutable closed : bool }
 
   type flow = Flow.flow
   type endpoint = Ipaddr.V4.t * int
@@ -45,7 +46,7 @@ module Httpaf
     match Ke.N.peek flow.queue with
     | [] ->
       if flow.rd_closed
-      then ( let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in Lwt.return () )
+      then ( let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in Lwt.return `Closed )
       else
         let len = min (Ke.available flow.queue) (Cstruct.len flow.rd) in
         let raw = Cstruct.sub flow.rd 0 len in
@@ -53,7 +54,8 @@ module Httpaf
             | Error err -> Lwt.fail (Recv_error err)
             | Ok `End_of_input ->
               let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
-              flow.rd_closed <- true ; Lwt.return ()
+              Log.debug (fun m -> m "[`read] Connection closed.") ;
+              flow.rd_closed <- true ; Lwt.return `Closed
             | Ok (`Input len) ->
               Log.debug (fun m -> m "<- %S" (Cstruct.to_string (Cstruct.sub raw 0 len))) ;
               let _ = Ke.N.push_exn flow.queue ~blit ~length:Cstruct.len ~off:0 ~len raw in
@@ -61,8 +63,9 @@ module Httpaf
     | src :: _ ->
       let len = Bigstringaf.length src in
       let shift = read src ~off:0 ~len in
+      Log.debug (fun m -> m "[`read] shift %d/%d byte(s)" shift len) ;
       Ke.N.shift_exn flow.queue shift ;
-      Lwt.return ()
+      Lwt.return `Continue
 
   let send flow iovecs =
     if flow.wr_closed then Lwt.return `Closed
@@ -84,10 +87,11 @@ module Httpaf
       go 0 iovecs
 
   let close flow =
-    if flow.rd_closed && flow.wr_closed
+    if flow.closed
     then Lwt.return ()
     else ( flow.rd_closed <- true
          ; flow.wr_closed <- true
+         ; flow.closed <- true
          ; Flow.close flow.flow >>= function
            | Ok () -> Lwt.return ()
            | Error err -> Lwt.fail (Close_error err) )
@@ -102,16 +106,23 @@ module Httpaf
           (request_handler edn) in
       let queue, _ = Ke.create ~capacity:0x1000 Bigarray.Char in
       let flow =
-        { flow; rd= Cstruct.create config.read_buffer_size; queue; rd_closed= false; wr_closed= false; } in
-      let rd_exit, notify_rd_exit = Lwt.wait () in
+        { flow; rd= Cstruct.create config.read_buffer_size; queue; rd_closed= false; wr_closed= false; closed= false; } in
+      let rd_exit, notify_rd_exit = Lwt.task () in
+      let wr_exit, notify_wr_exit = Lwt.task () in
       let rec rd_fiber () =
         let rec go () = match Server_connection.next_read_operation connection with
           | `Read ->
             Log.debug (fun m -> m "[`read]") ;
-            recv flow
+            ( recv flow
               ~read:(Server_connection.read connection)
-              ~read_eof:(Server_connection.read_eof connection) >>= fun () ->
-            Log.debug (fun m -> m "[`read] is done.") ; go ()
+              ~read_eof:(Server_connection.read_eof connection) >>= function
+              | `Closed ->
+                Log.debug (fun m -> m "[`read] Connection closed (wake-up threads)") ;
+                Lwt.wakeup notify_rd_exit () ;
+                Lwt.wakeup notify_wr_exit () ;
+                flow.rd_closed <- true ;
+                Lwt.return ()
+              | `Continue -> Log.debug (fun m -> m "[`read] is done.") ; go () )
           | `Yield ->
             Log.debug (fun m -> m "[read:`yield]") ;
             Server_connection.yield_reader connection rd_fiber ;
@@ -131,8 +142,11 @@ module Httpaf
             flow.rd_closed <- true ;
             Lwt.return () in
         Lwt.async @@ fun () ->
-        Lwt.catch go (fun exn -> Server_connection.report_exn connection exn ; Lwt.return ()) in
-      let wr_exit, notify_wr_exit = Lwt.wait () in
+        Lwt.catch go (fun exn ->
+            Server_connection.report_exn connection exn ;
+            Log.warn (fun m -> m "[`read] got an exception: %s" (Printexc.to_string exn)) ;
+            if Lwt.state rd_exit = Sleep then Lwt.wakeup notify_rd_exit () ;
+            Lwt.return ()) in
       let rec wr_fiber () =
         let rec go () = match Server_connection.next_write_operation connection with
           | `Write iovecs ->
@@ -150,7 +164,11 @@ module Httpaf
             flow.wr_closed <- true ;
             Lwt.return () in
         Lwt.async @@ fun () ->
-        Lwt.catch go (fun exn -> Server_connection.report_exn connection exn ; Lwt.return ()) in
+        Lwt.catch go (fun exn ->
+            Server_connection.report_exn connection exn ;
+            Log.warn (fun m -> m "[`write] got an exception: %s" (Printexc.to_string exn)) ;
+            if Lwt.state wr_exit = Sleep then Lwt.wakeup notify_wr_exit () ;
+            Lwt.return ()) in
       rd_fiber () ;
       wr_fiber () ;
       let threads = [ rd_exit; wr_exit; ] in
@@ -160,12 +178,11 @@ module Httpaf
           List.iter Lwt.cancel threads ;
           !Lwt.async_exception_hook v in
       List.iter (fun th -> Lwt.on_failure th catch_and_cancel) threads ;
-      Lwt.join threads >>= fun () ->
       let ip, port = edn in
+      Log.debug (fun m -> m "<%a:%d> waiting." Ipaddr.V4.pp ip port) ;
+      Lwt.join threads >>= fun () ->
       Log.debug (fun m -> m "close <%a:%d>." Ipaddr.V4.pp ip port) ;
-      if not flow.rd_closed || not flow.wr_closed
-      then close flow
-      else Lwt.return () in
+      close flow in
     connection_handler
 end
 

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -191,10 +191,10 @@ module Httpaf
     connection_handler
 end
 
-module Make (StackV4 : Mirage_stack.V4) = struct
+module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) = struct
   open Lwt.Infix
 
-  module TCP = Tuyau_mirage_tcp.Make(StackV4)
+  module TCP = Tuyau_mirage_tcp.Make(Time)(StackV4)
 
   let tls_endpoint, tls_protocol = Tuyau_mirage_tls.protocol_with_tls ~key:TCP.endpoint TCP.protocol
   let tls_configuration, tls_service = Tuyau_mirage_tls.service_with_tls ~key:TCP.configuration TCP.service tls_protocol

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,7 +1,7 @@
 open Tuyau_mirage
 
-module Make (StackV4 : Mirage_stack.V4) : sig
-  module TCP : module type of Tuyau_mirage_tcp.Make(StackV4)
+module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
+  module TCP : module type of Tuyau_mirage_tcp.Make(Time)(StackV4)
 
   val tls_endpoint : (TCP.endpoint * Tls.Config.client) key
   val tls_configuration : (TCP.configuration * Tls.Config.server) key

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,6 +1,6 @@
 open Tuyau_mirage
 
-module Make (StackV4 : Mirage_stack.V4) : sig
+module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
   module TCP : module type of Tuyau_mirage_tcp.Make(StackV4)
 
   val tls_endpoint : (TCP.endpoint * Tls.Config.client) key

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,7 +1,7 @@
 open Tuyau_mirage
 
-module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
-  module TCP : module type of Tuyau_mirage_tcp.Make(Time)(StackV4)
+module Make (StackV4 : Mirage_stack.V4) : sig
+  module TCP : module type of Tuyau_mirage_tcp.Make(StackV4)
 
   val tls_endpoint : (TCP.endpoint * Tls.Config.client) key
   val tls_configuration : (TCP.configuration * Tls.Config.server) key

--- a/paf.opam
+++ b/paf.opam
@@ -18,6 +18,7 @@ depends: [
   "tuyau"
   "tuyau-tls"
   "tuyau-mirage"
+  "mirage-time"
   "httpaf"
   "ke"
 ]

--- a/paf.opam
+++ b/paf.opam
@@ -16,6 +16,8 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "dune"
   "tuyau"
+  "tuyau-tls"
+  "tuyau-mirage"
   "httpaf"
   "ke"
 ]


### PR DESCRIPTION
This version want to fix a blocking `Flow.write` and add a time-out on it. Several time, blog.x25519.net just got an error because `paf` spawns 2 threads (about `read` and `write`) and it wants to join them. However, because `Flow.send` never returns (why? a bug on `mirage-tcpip`?), these threads are never `wakeup`.

We have several commits and each are tested, finally:
- update on the current interface of `tuyau`
- protect the flow on a double-close (eg. mutable close field)
- a `close` read wake-up all threads (not sure)
- if one thread got a failure, cancel others