### PR TITLE
Final version

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,8 @@
+version = 0.15.0
+break-infix = fit-or-vertical
+parse-docstrings = true
+indicate-multiline-delimiters=no
+nested-match=align
+sequence-style=separator
+break-before-in=auto
+if-then-else=keyword-first

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+## Paf le chien
+
+A port of HTTP/AF for MirageOS. It handles TLS connection with:
+- the new version of `conduit` (3.0.0)
+- `ocaml-tls`
+- `mirage-tcpip`
+
+This library wants to provide an easy way to start an HTTP/AF
+server with MirageOS. It provides a simple client too. The project,
+even if it was used by me for my unikernels, is a bit experimental.

--- a/lib/dune
+++ b/lib/dune
@@ -2,11 +2,13 @@
  (name paf)
  (public_name paf)
  (modules paf)
- (libraries mirage-time ke httpaf
+ (libraries
+    mirage-time
+    mirage-stack
+    ke httpaf
     conduit-tls
     conduit-mirage
-    conduit-mirage.tcp
-    conduit-mirage.tls))
+    conduit-mirage.tcp))
 
 (library
  (name mirage_paf)

--- a/lib/dune
+++ b/lib/dune
@@ -2,13 +2,8 @@
  (name paf)
  (public_name paf)
  (modules paf)
- (libraries
-    mirage-time
-    mirage-stack
-    ke httpaf
-    conduit-tls
-    conduit-mirage
-    conduit-mirage.tcp))
+ (libraries mirage-time mirage-stack ke httpaf conduit-tls conduit-mirage
+   conduit-mirage.tcp))
 
 (library
  (name mirage_paf)

--- a/lib/mirage_paf.ml
+++ b/lib/mirage_paf.ml
@@ -3,29 +3,46 @@ open Mirage
 let pin_conduit = "git+https://github.com/dinosaure/ocaml-conduit.git#3.0.0"
 
 type conduit = Conduit
+
 let conduit = Type Conduit
 
-let conduit = impl @@ object
-  inherit base_configurable
-  method ty = conduit
-  method name = "conduit"
-  method module_name = "Conduit_mirage"
-  method! packages = Key.pure
-      [ package ~pin:pin_conduit "conduit"
-      ; package ~pin:pin_conduit "conduit-lwt"
-      ; package ~pin:pin_conduit "conduit-mirage" ]
-end
+let conduit =
+  impl
+  @@ object
+       inherit base_configurable
+
+       method ty = conduit
+
+       method name = "conduit"
+
+       method module_name = "Conduit_mirage"
+
+       method! packages =
+         Key.pure
+           [
+             package ~pin:pin_conduit "conduit";
+             package ~pin:pin_conduit "conduit-lwt";
+             package ~pin:pin_conduit "conduit-mirage";
+           ]
+     end
 
 type paf = Paf
+
 let paf = Type Paf
 
-let httpaf = impl @@ object
-  inherit base_configurable
-  method ty = time @-> stackv4 @-> paf
-  method name = "paf"
-  method module_name = "Paf.Make"
-  method! packages = Key.pure
-      [ package "paf"
-      ; package ~pin:pin_conduit "conduit-tls" ]
-  method! deps = [ abstract conduit ]
-end
+let httpaf =
+  impl
+  @@ object
+       inherit base_configurable
+
+       method ty = time @-> stackv4 @-> paf
+
+       method name = "paf"
+
+       method module_name = "Paf.Make"
+
+       method! packages =
+         Key.pure [ package "paf"; package ~pin:pin_conduit "conduit-tls" ]
+
+       method! deps = [ abstract conduit ]
+     end

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -3,146 +3,161 @@ module Conduit_mirage_tls = Conduit_tls.Make (Lwt) (Conduit_mirage)
 module type HTTPAF = sig
   type flow
 
-  exception Send_error  of string
-  exception Recv_error  of string
+  exception Send_error of string
+
+  exception Recv_error of string
+
   exception Close_error of string
 
-  val create_server_connection_handler
-    :  ?config:Httpaf.Config.t
-    -> request_handler:('endpoint -> Httpaf.Server_connection.request_handler)
-    -> error_handler:('endpoint -> Httpaf.Server_connection.error_handler)
-    -> 'endpoint
-    -> flow
-    -> unit Lwt.t
+  val create_server_connection_handler :
+    ?config:Httpaf.Config.t ->
+    request_handler:('endpoint -> Httpaf.Server_connection.request_handler) ->
+    error_handler:('endpoint -> Httpaf.Server_connection.error_handler) ->
+    'endpoint ->
+    flow ->
+    unit Lwt.t
 
-  val request
-    :  ?tls:bool
-    -> ?config:Httpaf.Config.t
-    -> flow
-    -> 'endpoint
-    -> Httpaf.Request.t
-    -> error_handler:(flow -> 'endpoint -> Httpaf.Client_connection.error_handler)
-    -> response_handler:('endpoint -> Httpaf.Client_connection.response_handler)
-    -> [ `write ] Httpaf.Body.t
+  val request :
+    ?tls:bool ->
+    ?config:Httpaf.Config.t ->
+    flow ->
+    'endpoint ->
+    Httpaf.Request.t ->
+    error_handler:(flow -> 'endpoint -> Httpaf.Client_connection.error_handler) ->
+    response_handler:('endpoint -> Httpaf.Client_connection.response_handler) ->
+    [ `write ] Httpaf.Body.t
 end
 
 module Httpaf
-    (Conduit : Conduit.S with type 'a io = 'a Lwt.t
-                          and type input = Cstruct.t
-                          and type output = Cstruct.t)
+    (Conduit : Conduit.S
+                 with type 'a io = 'a Lwt.t
+                  and type input = Cstruct.t
+                  and type output = Cstruct.t)
     (Time : Mirage_time.S) : HTTPAF with type flow = Conduit.flow = struct
   let src = Logs.Src.create "paf"
+
   module Log = (val Logs.src_log src : Logs.LOG)
+
   module We = Ke.Rke.Weighted
-  
-  type server =
-    { flow  : Conduit.flow
-    ; tmp   : Cstruct.t
-    ; queue : (char, Bigarray.int8_unsigned_elt) We.t
-    ; mutable rd_closed : bool
-    ; mutable wr_closed : bool }
+
+  type server = {
+    flow : Conduit.flow;
+    tmp : Cstruct.t;
+    queue : (char, Bigarray.int8_unsigned_elt) We.t;
+    mutable rd_closed : bool;
+    mutable wr_closed : bool;
+  }
+
   and flow = Conduit.flow
-  
-  exception Recv_error  of string
-  exception Send_error  of string
+
+  exception Recv_error of string
+
+  exception Send_error of string
+
   exception Close_error of string
-  
+
   open Lwt.Infix
-  
+
   let blit src src_off dst dst_off len =
     let src = Cstruct.to_bigarray src in
     Bigstringaf.blit src ~src_off dst ~dst_off ~len
 
   let safely_close flow =
     if flow.rd_closed && flow.wr_closed
-    then
-      ( Log.debug (fun m -> m "Close the connection.")
-      ; Conduit.close flow.flow >>= function
+    then (
+      Log.debug (fun m -> m "Close the connection.") ;
+      Conduit.close flow.flow >>= function
       | Error `Not_found -> assert false
       | Error (`Msg err) ->
-        Log.err (fun m -> m "Got an error when closing: %s" err) ;
-        Lwt.fail (Close_error err)
-      | Ok () -> Lwt.return () )
+          Log.err (fun m -> m "Got an error when closing: %s" err) ;
+          Lwt.fail (Close_error err)
+      | Ok () -> Lwt.return ())
     else Lwt.return ()
-  
+
   let rec recv flow ~read ~read_eof =
     match We.N.peek flow.queue with
-    | [] ->
-      if flow.rd_closed
-      then ( let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in Lwt.return `Closed )
-      else
-        let len = min (We.available flow.queue) (Cstruct.len flow.tmp) in
-        let raw = Cstruct.sub flow.tmp 0 len in
-        ( Conduit.recv flow.flow raw >>= function
-            | Error (`Msg err) ->
+    | [] -> (
+        if flow.rd_closed
+        then
+          let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
+          Lwt.return `Closed
+        else
+          let len = min (We.available flow.queue) (Cstruct.len flow.tmp) in
+          let raw = Cstruct.sub flow.tmp 0 len in
+          Conduit.recv flow.flow raw >>= function
+          | Error (`Msg err) ->
               flow.rd_closed <- true ;
-              safely_close flow >>= fun () ->
-              Lwt.fail (Recv_error err)
-            | Error `Not_found -> assert false
-            | Ok `End_of_flow ->
+              safely_close flow >>= fun () -> Lwt.fail (Recv_error err)
+          | Error `Not_found -> assert false
+          | Ok `End_of_flow ->
               let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
               Log.debug (fun m -> m "[`read] Connection closed.") ;
               flow.rd_closed <- true ;
               safely_close flow >>= fun () -> Lwt.return `Closed
-            | Ok (`Input len) ->
+          | Ok (`Input len) ->
               Log.debug (fun m -> m "<- %d byte(s)" len) ;
-              let _ = We.N.push_exn flow.queue ~blit ~length:Cstruct.len ~off:0 ~len raw in
-              recv flow ~read ~read_eof )
+              let _ =
+                We.N.push_exn flow.queue ~blit ~length:Cstruct.len ~off:0 ~len
+                  raw in
+              recv flow ~read ~read_eof)
     | src :: _ ->
-      let len = Bigstringaf.length src in
-      let shift = read src ~off:0 ~len in
-      Log.debug (fun m -> m "[`read] shift %d/%d byte(s)" shift len) ;
-      We.N.shift_exn flow.queue shift ;
-      if shift = 0 then We.compress flow.queue ;
-      Lwt.return `Continue
- 
-  let writev ?(timeout= 5_000_000_000L) flow iovecs =
-    let sleep () = Time.sleep_ns timeout >>= fun () -> Lwt.return (Error `Timeout) in
-  
+        let len = Bigstringaf.length src in
+        let shift = read src ~off:0 ~len in
+        Log.debug (fun m -> m "[`read] shift %d/%d byte(s)" shift len) ;
+        We.N.shift_exn flow.queue shift ;
+        if shift = 0 then We.compress flow.queue ;
+        Lwt.return `Continue
+
+  let writev ?(timeout = 5_000_000_000L) flow iovecs =
+    let sleep () =
+      Time.sleep_ns timeout >>= fun () -> Lwt.return (Error `Timeout) in
+
     let rec go n = function
       | [] -> Lwt.return (`Ok n)
-      | { Faraday.buffer; off; len; } :: rest ->
-        let raw = Cstruct.of_bigarray buffer ~off ~len in
-        Lwt.pick
-          [ Conduit.send flow.flow raw
-          ; sleep () ] >>= function
-        | Ok shift ->
-          if shift = len
-          then go (n + shift) rest
-          else go (n + shift) ({ Faraday.buffer; off= off + shift; len= len - shift; } :: rest)
-        | Error `Timeout ->
-          flow.wr_closed <- true ;
-          safely_close flow >>= fun () ->
-          Lwt.return `Closed
-        | Error (`Msg err) ->
-          Log.err (fun m -> m "Got an error while writing: %s." err) ;
-          flow.wr_closed <- true ;
-          safely_close flow >>= fun () ->
-          Lwt.fail (Send_error err)
-        | Error `Not_found -> assert false in
+      | { Faraday.buffer; off; len } :: rest -> (
+          let raw = Cstruct.of_bigarray buffer ~off ~len in
+          Lwt.pick [ Conduit.send flow.flow raw; sleep () ] >>= function
+          | Ok shift ->
+              if shift = len
+              then go (n + shift) rest
+              else
+                go (n + shift)
+                  ({ Faraday.buffer; off = off + shift; len = len - shift }
+                  :: rest)
+          | Error `Timeout ->
+              flow.wr_closed <- true ;
+              safely_close flow >>= fun () -> Lwt.return `Closed
+          | Error (`Msg err) ->
+              Log.err (fun m -> m "Got an error while writing: %s." err) ;
+              flow.wr_closed <- true ;
+              safely_close flow >>= fun () -> Lwt.fail (Send_error err)
+          | Error `Not_found -> assert false) in
     go 0 iovecs
-  
+
   let send flow iovecs =
     if flow.wr_closed
     then safely_close flow >>= fun () -> Lwt.return `Closed
     else writev flow iovecs
-  
+
   let close flow =
-    if (not flow.rd_closed && flow.wr_closed) || (flow.rd_closed && not flow.wr_closed)
-    then ( flow.rd_closed <- true
-         ; flow.wr_closed <- true
-         ; Log.debug (fun m -> m "Properly close the connection.")
-         ; Conduit.close flow.flow >>= function
-           | Ok () ->
-             Log.debug (fun m -> m "Connection closed.") ;
-             Lwt.return ()
-           | Error `Not_found -> assert false
-           | Error (`Msg err) ->
-             Log.err (fun m -> m "Got an error when closing: %s." err) ;
-             Lwt.fail (Close_error err) )
+    if ((not flow.rd_closed) && flow.wr_closed)
+       || (flow.rd_closed && not flow.wr_closed)
+    then (
+      flow.rd_closed <- true ;
+      flow.wr_closed <- true ;
+      Log.debug (fun m -> m "Properly close the connection.") ;
+      Conduit.close flow.flow >>= function
+      | Ok () ->
+          Log.debug (fun m -> m "Connection closed.") ;
+          Lwt.return ()
+      | Error `Not_found -> assert false
+      | Error (`Msg err) ->
+          Log.err (fun m -> m "Got an error when closing: %s." err) ;
+          Lwt.fail (Close_error err))
     else Lwt.return ()
-  
-  let create_server_connection_handler ?(config= Httpaf.Config.default) ~request_handler ~error_handler =
+
+  let create_server_connection_handler ?(config = Httpaf.Config.default)
+      ~request_handler ~error_handler =
     let connection_handler edn flow =
       let module Server_connection = Httpaf.Server_connection in
       let connection =
@@ -150,49 +165,54 @@ module Httpaf
           (request_handler edn) in
       let queue, _ = We.create ~capacity:0x1000 Bigarray.char in
       let flow =
-        { flow
-        ; tmp= Cstruct.create config.read_buffer_size
-        ; queue
-        ; rd_closed= false; wr_closed= false; } in
+        {
+          flow;
+          tmp = Cstruct.create config.read_buffer_size;
+          queue;
+          rd_closed = false;
+          wr_closed = false;
+        } in
       let rd_exit, notify_rd_exit = Lwt.task () in
       let wr_exit, notify_wr_exit = Lwt.task () in
       let rec rd_fiber () =
-        let rec go () = match Server_connection.next_read_operation connection with
+        let rec go () =
+          match Server_connection.next_read_operation connection with
           | `Read ->
-            Log.debug (fun m -> m "next read operation: `read") ;
-            recv flow
-              ~read:(Server_connection.read connection)
-              ~read_eof:(Server_connection.read_eof connection) >>= fun _ ->
-            go ()
+              Log.debug (fun m -> m "next read operation: `read") ;
+              recv flow
+                ~read:(Server_connection.read connection)
+                ~read_eof:(Server_connection.read_eof connection)
+              >>= fun _ -> go ()
           | `Yield ->
-            Log.debug (fun m -> m "next read operation: `yield") ;
-            Server_connection.yield_reader connection rd_fiber ;
-            Lwt.return ()
+              Log.debug (fun m -> m "next read operation: `yield") ;
+              Server_connection.yield_reader connection rd_fiber ;
+              Lwt.return ()
           | `Close ->
-            Log.debug (fun m -> m "next read operation: `close") ;
-            Lwt.wakeup_later notify_rd_exit () ;
-            flow.rd_closed <- true ;
-            safely_close flow in
+              Log.debug (fun m -> m "next read operation: `close") ;
+              Lwt.wakeup_later notify_rd_exit () ;
+              flow.rd_closed <- true ;
+              safely_close flow in
         Lwt.async @@ fun () ->
         Lwt.catch go (fun exn ->
             Server_connection.report_exn connection exn ;
             Lwt.return ()) in
       let rec wr_fiber () =
-        let rec go () = match Server_connection.next_write_operation connection with
+        let rec go () =
+          match Server_connection.next_write_operation connection with
           | `Write iovecs ->
-            Log.debug (fun m -> m "next write operation: `write") ;
-            send flow iovecs >>= fun res ->
-            Server_connection.report_write_result connection res ;
-            go ()
+              Log.debug (fun m -> m "next write operation: `write") ;
+              send flow iovecs >>= fun res ->
+              Server_connection.report_write_result connection res ;
+              go ()
           | `Yield ->
-            Log.debug (fun m -> m "next write operation: `yield") ;
-            Server_connection.yield_writer connection wr_fiber ;
-            Lwt.return ()
+              Log.debug (fun m -> m "next write operation: `yield") ;
+              Server_connection.yield_writer connection wr_fiber ;
+              Lwt.return ()
           | `Close _ ->
-            Log.debug (fun m -> m "next write operation: `close") ;
-            Lwt.wakeup_later notify_wr_exit () ;
-            flow.wr_closed <- true ;
-            safely_close flow in
+              Log.debug (fun m -> m "next write operation: `close") ;
+              Lwt.wakeup_later notify_wr_exit () ;
+              flow.wr_closed <- true ;
+              safely_close flow in
         Lwt.async @@ fun () ->
         Lwt.catch go (fun exn ->
             Server_connection.report_write_result connection `Closed ;
@@ -200,7 +220,7 @@ module Httpaf
             Lwt.return ()) in
       rd_fiber () ;
       wr_fiber () ;
-      let threads = [ rd_exit; wr_exit; ] in
+      let threads = [ rd_exit; wr_exit ] in
       Lwt.join threads >>= fun () ->
       Log.debug (fun m -> m "End of transmission.") ;
       close flow in
@@ -208,63 +228,70 @@ module Httpaf
 
   module Qe = Ke.Rke
 
-  type client =
-    { flow  : Conduit.flow
-    ; tmp   : Cstruct.t
-    ; queue : (char, Bigarray.int8_unsigned_elt) Qe.t
-    ; mutable rd_closed : bool
-    ; mutable wr_closed : bool }
+  type client = {
+    flow : Conduit.flow;
+    tmp : Cstruct.t;
+    queue : (char, Bigarray.int8_unsigned_elt) Qe.t;
+    mutable rd_closed : bool;
+    mutable wr_closed : bool;
+  }
 
   let safely_close flow =
     if flow.rd_closed && flow.wr_closed
-    then
-      ( Log.debug (fun m -> m "Close the connection.")
-      ; Conduit.close flow.flow >>= function
+    then (
+      Log.debug (fun m -> m "Close the connection.") ;
+      Conduit.close flow.flow >>= function
       | Error `Not_found -> assert false
       | Error (`Msg err) ->
-        Log.err (fun m -> m "Got an error when closing: %s" err) ;
-        Lwt.fail (Close_error err)
-      | Ok () -> Lwt.return () )
+          Log.err (fun m -> m "Got an error when closing: %s" err) ;
+          Lwt.fail (Close_error err)
+      | Ok () -> Lwt.return ())
     else Lwt.return ()
 
   let no_lock f = f ()
 
-  let with_lock : ?mutex:Lwt_mutex.t -> ((unit -> 'a Lwt.t) -> 'a Lwt.t)
-    = fun ?mutex -> match mutex with
+  let with_lock : ?mutex:Lwt_mutex.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t =
+   fun ?mutex ->
+    match mutex with
     | Some mutex -> fun f -> Lwt_mutex.with_lock mutex f
     | None -> no_lock
 
   let rec really_recv ?tls flow ~read ~read_eof =
-    let len = (Cstruct.len flow.tmp) in
+    let len = Cstruct.len flow.tmp in
     let raw = Cstruct.sub flow.tmp 0 len in
-    ( with_lock ?mutex:tls (fun () ->
-          Lwt.catch (fun () -> Conduit.recv flow.flow raw) 
-          (fun exn -> Lwt.return_error (`Exn exn))) >>= function
-        | Error `Not_found -> assert false
-        | Error (`Exn _) ->
-          flow.rd_closed <- true ;
-          safely_close flow >>= fun () -> Lwt.return `Closed
-        | Error (`Msg _) ->
-          flow.rd_closed <- true ;
-          safely_close flow >>= fun () -> Lwt.return `Closed
-          (* Lwt.fail (Recv_error err) *)
-        | Ok `End_of_flow ->
-          let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
-          Log.debug (fun m -> m "[`read] Connection closed.") ;
-          flow.rd_closed <- true ;
-          safely_close flow >>= fun () -> Lwt.return `Closed
-        | Ok (`Input len) ->
-          Log.debug (fun m -> m "<- %d byte(s)" len) ;
-          Qe.N.push flow.queue ~blit ~length:Cstruct.len ~off:0 ~len raw ;
-          recv ?tls flow ~read ~read_eof )
+    with_lock ?mutex:tls (fun () ->
+        Lwt.catch
+          (fun () -> Conduit.recv flow.flow raw)
+          (fun exn -> Lwt.return_error (`Exn exn)))
+    >>= function
+    | Error `Not_found -> assert false
+    | Error (`Exn _) ->
+        flow.rd_closed <- true ;
+        safely_close flow >>= fun () -> Lwt.return `Closed
+    | Error (`Msg _) ->
+        flow.rd_closed <- true ;
+        safely_close flow >>= fun () -> Lwt.return `Closed
+        (* Lwt.fail (Recv_error err) *)
+    | Ok `End_of_flow ->
+        let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
+        Log.debug (fun m -> m "[`read] Connection closed.") ;
+        flow.rd_closed <- true ;
+        safely_close flow >>= fun () -> Lwt.return `Closed
+    | Ok (`Input len) ->
+        Log.debug (fun m -> m "<- %d byte(s)" len) ;
+        Qe.N.push flow.queue ~blit ~length:Cstruct.len ~off:0 ~len raw ;
+        recv ?tls flow ~read ~read_eof
 
   and recv ?tls flow ~read ~read_eof =
     match Qe.N.peek flow.queue with
     | [] ->
-      if flow.rd_closed
-      then ( let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in Lwt.return `Closed )
-      else really_recv ?tls flow ~read ~read_eof
-        (*
+        if flow.rd_closed
+        then
+          let _ (* 0 *) = read_eof Bigstringaf.empty ~off:0 ~len:0 in
+          Lwt.return `Closed
+        else
+          really_recv ?tls flow ~read ~read_eof
+          (*
         let len = (Cstruct.len flow.tmp) in
         let raw = Cstruct.sub flow.tmp 0 len in
         ( with_lock ?mutex:tls (fun () ->
@@ -288,67 +315,78 @@ module Httpaf
               Qe.N.push flow.queue ~blit ~length:Cstruct.len ~off:0 ~len raw ;
               recv ?tls flow ~read ~read_eof ) *)
     | src :: _ ->
-      let len = Bigstringaf.length src in
-      Log.debug (fun m -> m "transmit %d byte(s)" len) ;
-      let shift = read src ~off:0 ~len in
-      Log.debug (fun m -> m "[`read] shift %d/%d byte(s)" shift len) ;
-      Qe.N.shift_exn flow.queue shift ;
-      if shift = 0
-      then ( Qe.compress flow.queue ; really_recv ?tls flow ~read ~read_eof )
-      else Lwt.return `Continue
+        let len = Bigstringaf.length src in
+        Log.debug (fun m -> m "transmit %d byte(s)" len) ;
+        let shift = read src ~off:0 ~len in
+        Log.debug (fun m -> m "[`read] shift %d/%d byte(s)" shift len) ;
+        Qe.N.shift_exn flow.queue shift ;
+        if shift = 0
+        then (
+          Qe.compress flow.queue ;
+          really_recv ?tls flow ~read ~read_eof)
+        else Lwt.return `Continue
 
   let drain ?tls:_ flow ~read:_ ~read_eof =
-    let go () = match Qe.N.peek flow.queue with
+    let go () =
+      match Qe.N.peek flow.queue with
       | [] ->
-        Log.debug (fun m -> m "[`drain] empty queue.") ;
-        let _ = read_eof Bigstringaf.empty ~off:0 ~len:0 in
-        Lwt.return ()
+          Log.debug (fun m -> m "[`drain] empty queue.") ;
+          let _ = read_eof Bigstringaf.empty ~off:0 ~len:0 in
+          Lwt.return ()
       | src :: _ ->
-        Log.debug (fun m -> m "[`drain] %d byte(s)." (Bigstringaf.length src)) ;
-        let _ = read_eof src ~off:0 ~len:(Bigstringaf.length src) in
-        Lwt.return () in
-    Qe.compress flow.queue ; go ()
+          Log.debug (fun m -> m "[`drain] %d byte(s)." (Bigstringaf.length src)) ;
+          let _ = read_eof src ~off:0 ~len:(Bigstringaf.length src) in
+          Lwt.return () in
+    Qe.compress flow.queue ;
+    go ()
 
-  let writev ?tls ?(timeout= 1000000000L) flow iovecs =
-    let sleep () = Time.sleep_ns timeout >>= fun () -> Lwt.return (Error `Timeout) in
-  
+  let writev ?tls ?(timeout = 1000000000L) flow iovecs =
+    let sleep () =
+      Time.sleep_ns timeout >>= fun () -> Lwt.return (Error `Timeout) in
+
     let rec go n = function
       | [] -> Lwt.return (`Ok n)
-      | { Faraday.buffer; off; len; } :: rest ->
-        let raw = Cstruct.of_bigarray buffer ~off ~len in
-        Lwt.pick
-          [ with_lock ?mutex:tls (fun () -> Conduit.send flow.flow raw)
-          ; sleep () ] >>= function
-        | Ok shift ->
-          if shift = len
-          then go (n + shift) rest
-          else go (n + shift) ({ Faraday.buffer; off= off + shift; len= len - shift; } :: rest)
-        | Error `Not_found -> assert false
-        | Error `Timeout ->
-          flow.wr_closed <- true ;
-          safely_close flow >>= fun () ->
-          Lwt.return `Closed
-        | Error (`Msg err) ->
-          Log.err (fun m -> m "Got an error while reading: %s." err) ;
-          Lwt.fail (Send_error err) in
+      | { Faraday.buffer; off; len } :: rest -> (
+          let raw = Cstruct.of_bigarray buffer ~off ~len in
+          Lwt.pick
+            [
+              with_lock ?mutex:tls (fun () -> Conduit.send flow.flow raw);
+              sleep ();
+            ]
+          >>= function
+          | Ok shift ->
+              if shift = len
+              then go (n + shift) rest
+              else
+                go (n + shift)
+                  ({ Faraday.buffer; off = off + shift; len = len - shift }
+                  :: rest)
+          | Error `Not_found -> assert false
+          | Error `Timeout ->
+              flow.wr_closed <- true ;
+              safely_close flow >>= fun () -> Lwt.return `Closed
+          | Error (`Msg err) ->
+              Log.err (fun m -> m "Got an error while reading: %s." err) ;
+              Lwt.fail (Send_error err)) in
     go 0 iovecs
 
   let close ?tls flow =
-    if (not flow.rd_closed && flow.wr_closed) || (flow.rd_closed && not flow.wr_closed)
-    then ( flow.rd_closed <- true
-         ; flow.wr_closed <- true
-         ; Log.debug (fun m -> m "Properly close the connection.")
-         ; with_lock ?mutex:tls (fun () -> Conduit.close flow.flow) >>= function
-           | Ok () ->
-             Log.debug (fun m -> m "Connection properly closed.") ;
-             Lwt.return ()
-           | Error `Not_found -> assert false
-           | Error (`Msg err) -> Lwt.fail (Close_error err) )
+    if ((not flow.rd_closed) && flow.wr_closed)
+       || (flow.rd_closed && not flow.wr_closed)
+    then (
+      flow.rd_closed <- true ;
+      flow.wr_closed <- true ;
+      Log.debug (fun m -> m "Properly close the connection.") ;
+      with_lock ?mutex:tls (fun () -> Conduit.close flow.flow) >>= function
+      | Ok () ->
+          Log.debug (fun m -> m "Connection properly closed.") ;
+          Lwt.return ()
+      | Error `Not_found -> assert false
+      | Error (`Msg err) -> Lwt.fail (Close_error err))
     else Lwt.return ()
 
-  let request
-      ?(tls= false)
-      ?(config= Httpaf.Config.default) flow edn request ~error_handler ~response_handler =
+  let request ?(tls = false) ?(config = Httpaf.Config.default) flow edn request
+      ~error_handler ~response_handler =
     let module Client_connection = Httpaf.Client_connection in
     let request_body, connection =
       Client_connection.request ~config request
@@ -357,38 +395,39 @@ module Httpaf
     let tls = if tls then Some (Lwt_mutex.create ()) else None in
     let queue = Qe.create ~capacity:config.read_buffer_size Bigarray.char in
     let tmp = Cstruct.create config.read_buffer_size in
-    let flow = { flow; queue; tmp; rd_closed= false; wr_closed= false; } in
+    let flow = { flow; queue; tmp; rd_closed = false; wr_closed = false } in
     let read_loop_exited, notify_read_loop_exited = Lwt.wait () in
 
     let rd_loop () =
       let rec go () =
         match Client_connection.next_read_operation connection with
-        | `Read ->
-          Log.debug (fun m -> m "[`read] start to read.") ;
-          let read = Client_connection.read connection in
-          let read_eof = Client_connection.read_eof connection in
-          ( recv ?tls flow ~read ~read_eof >>= function
-          | `Closed ->
-            Log.err (fun m -> m "[`read] connection was closed by peer.") ;
+        | `Read -> (
+            Log.debug (fun m -> m "[`read] start to read.") ;
+            let read = Client_connection.read connection in
+            let read_eof = Client_connection.read_eof connection in
+            recv ?tls flow ~read ~read_eof >>= function
+            | `Closed ->
+                Log.err (fun m -> m "[`read] connection was closed by peer.") ;
+                Lwt.wakeup_later notify_read_loop_exited () ;
+                flow.rd_closed <- true ;
+                safely_close flow
+            | _ -> go ())
+        | `Close ->
+            Log.debug (fun m -> m "[`read] close the connection.") ;
+            let read = Client_connection.read connection in
+            let read_eof = Client_connection.read_eof connection in
+            drain ?tls flow ~read ~read_eof >>= fun () ->
             Lwt.wakeup_later notify_read_loop_exited () ;
             flow.rd_closed <- true ;
-            safely_close flow
-          | _ -> go () )
-        | `Close ->
-          Log.debug (fun m -> m "[`read] close the connection.") ;
-          let read = Client_connection.read connection in
-          let read_eof = Client_connection.read_eof connection in
-          drain ?tls flow ~read ~read_eof >>= fun () ->
-          Lwt.wakeup_later notify_read_loop_exited () ;
-          flow.rd_closed <- true ;
-          safely_close flow in
-      Lwt.async (fun () -> Lwt.catch go
-                    (fun exn ->
-                       Log.err (fun m -> m "report a read error: %s" (Printexc.to_string exn)) ;
-                       Lwt.wakeup_later notify_read_loop_exited () ;
-                       Client_connection.report_exn connection exn ;
-                       Client_connection.shutdown connection ;
-                       Lwt.return ())) in
+            safely_close flow in
+      Lwt.async (fun () ->
+          Lwt.catch go (fun exn ->
+              Log.err (fun m ->
+                  m "report a read error: %s" (Printexc.to_string exn)) ;
+              Lwt.wakeup_later notify_read_loop_exited () ;
+              Client_connection.report_exn connection exn ;
+              Client_connection.shutdown connection ;
+              Lwt.return ())) in
     let writev ?tls = writev ?tls flow in
     let write_loop_exited, notify_write_loop_exited = Lwt.wait () in
 
@@ -396,26 +435,28 @@ module Httpaf
       let rec go () =
         match Client_connection.next_write_operation connection with
         | `Write iovecs ->
-          Log.debug (fun m -> m "[`write] start to write.") ;
-          writev ?tls iovecs >>= fun res ->
-          Client_connection.report_write_result connection res ;
-          go ()
+            Log.debug (fun m -> m "[`write] start to write.") ;
+            writev ?tls iovecs >>= fun res ->
+            Client_connection.report_write_result connection res ;
+            go ()
         | `Yield ->
-          Log.debug (fun m -> m "[`write] yield.") ;
-          Client_connection.yield_writer connection wr_loop ;
-          Lwt.return ()
+            Log.debug (fun m -> m "[`write] yield.") ;
+            Client_connection.yield_writer connection wr_loop ;
+            Lwt.return ()
         | `Close _ ->
-          Log.debug (fun m -> m "[`write] close.") ;
-          Lwt.wakeup_later notify_write_loop_exited () ;
-          Lwt.return () in
+            Log.debug (fun m -> m "[`write] close.") ;
+            Lwt.wakeup_later notify_write_loop_exited () ;
+            Lwt.return () in
 
-      Lwt.async (fun () -> Lwt.catch go
-                    (fun exn ->
-                       Log.err (fun m -> m "report a write error: %s" (Printexc.to_string exn)) ;
-                       Client_connection.report_exn connection exn ;
-                       Lwt.return ())) in
+      Lwt.async (fun () ->
+          Lwt.catch go (fun exn ->
+              Log.err (fun m ->
+                  m "report a write error: %s" (Printexc.to_string exn)) ;
+              Client_connection.report_exn connection exn ;
+              Lwt.return ())) in
     (* XXX(dinosaure): we trust on [write] will be the first call. *)
-    wr_loop () ; rd_loop () ;
+    wr_loop () ;
+    rd_loop () ;
     Lwt.async (fun () ->
         Lwt.join [ read_loop_exited; write_loop_exited ] >>= fun () ->
         Log.debug (fun m -> m "End of transmission.") ;
@@ -425,11 +466,11 @@ end
 
 module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) = struct
   open Lwt.Infix
-
-  module TCP = Conduit_mirage_tcp.Make(StackV4)
-  module Httpaf = Httpaf(Conduit_mirage)(Time)
+  module TCP = Conduit_mirage_tcp.Make (StackV4)
+  module Httpaf = Httpaf (Conduit_mirage) (Time)
 
   let tls_protocol = Conduit_mirage_tls.protocol_with_tls TCP.protocol
+
   let tls_service = Conduit_mirage_tls.service_with_tls TCP.service tls_protocol
 
   include Httpaf
@@ -437,44 +478,59 @@ module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) = struct
   let http ?config ~error_handler ~request_handler master =
     let module Service = (val Conduit_mirage.Service.impl TCP.service) in
     let handler edn flow =
-      create_server_connection_handler ?config ~error_handler ~request_handler edn flow in
+      create_server_connection_handler ?config ~error_handler ~request_handler
+        edn flow in
     let rec go () =
       let open Lwt.Infix in
       Service.accept master >>= function
       | Error err -> Lwt.return (Rresult.R.error_msgf "%a" Service.pp_error err)
       | Ok flow ->
-        let edn = TCP.dst flow in
-        Lwt.async (fun () -> handler edn (Conduit_mirage.pack TCP.protocol flow)) ; Lwt.pause () >>= go in
+          let edn = TCP.dst flow in
+          Lwt.async (fun () ->
+              handler edn (Conduit_mirage.pack TCP.protocol flow)) ;
+          Lwt.pause () >>= go in
     go ()
 
   let https ?config ~error_handler ~request_handler master =
     let open Rresult in
     let module Service = (val Conduit_mirage.Service.impl tls_service) in
     let handler edn flow =
-      create_server_connection_handler ?config ~error_handler ~request_handler edn flow in
+      create_server_connection_handler ?config ~error_handler ~request_handler
+        edn flow in
     let rec go () =
       let open Lwt.Infix in
       Service.accept master >>= function
       | Error err -> Lwt.return (Rresult.R.error_msgf "%a" Service.pp_error err)
       | Ok flow ->
-        let edn = TCP.dst (Conduit_mirage_tls.underlying flow) in
-        Lwt.async (fun () -> handler edn (Conduit_mirage.pack tls_protocol flow)) ; Lwt.pause () >>= go in
+          let edn = TCP.dst (Conduit_mirage_tls.underlying flow) in
+          Lwt.async (fun () ->
+              handler edn (Conduit_mirage.pack tls_protocol flow)) ;
+          Lwt.pause () >>= go in
     go ()
 
   let failwith fmt = Format.kasprintf (fun err -> Lwt.fail (Failure err)) fmt
 
-  let request ?config ~resolvers ~error_handler ~response_handler domain_name v =
+  let request ?config ~resolvers ~error_handler ~response_handler domain_name v
+      =
     Conduit_mirage.resolve resolvers domain_name >>= function
     | Error _ as err -> Lwt.return err
     | Ok flow ->
-      match Conduit_mirage.cast flow tls_protocol,
-            Conduit_mirage.cast flow TCP.protocol with
-      | Some tls, None ->
+    match
+      ( Conduit_mirage.cast flow tls_protocol,
+        Conduit_mirage.cast flow TCP.protocol )
+    with
+    | Some tls, None ->
         let ip, port = TCP.dst (Conduit_mirage_tls.underlying tls) in
-        Lwt.return_ok (request ~tls:true ?config flow (Some (ip, port)) v ~error_handler ~response_handler)
-      | None, Some protocol ->
+        Lwt.return_ok
+          (request ~tls:true ?config flow
+             (Some (ip, port))
+             v ~error_handler ~response_handler)
+    | None, Some protocol ->
         let ip, port = TCP.dst protocol in
-        Lwt.return_ok (request ?config flow (Some (ip, port)) v ~error_handler ~response_handler)
-      | Some _, Some _ -> assert false (* tls_protocol <> TCP.protocol *)
-      | None, None -> failwith "Unrecognized conduit's protocol"
+        Lwt.return_ok
+          (request ?config flow
+             (Some (ip, port))
+             v ~error_handler ~response_handler)
+    | Some _, Some _ -> assert false (* tls_protocol <> TCP.protocol *)
+    | None, None -> failwith "Unrecognized conduit's protocol"
 end

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -96,7 +96,7 @@ module Httpaf
       if shift = 0 then We.compress flow.queue ;
       Lwt.return `Continue
  
-  let writev ?(timeout= 1000000000L) flow iovecs =
+  let writev ?(timeout= 5_000_000_000L) flow iovecs =
     let sleep () = Time.sleep_ns timeout >>= fun () -> Lwt.return (Error `Timeout) in
   
     let rec go n = function

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,37 +1,52 @@
-module Conduit_mirage_tls : module type of Conduit_tls.Make (Lwt) (Conduit_mirage)
+module Conduit_mirage_tls :
+    module type of Conduit_tls.Make (Lwt) (Conduit_mirage)
 
 module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
-  module TCP : module type of Conduit_mirage_tcp.Make(StackV4)
+  module TCP : module type of Conduit_mirage_tcp.Make (StackV4)
 
-  val tls_protocol : ((StackV4.t, Ipaddr.V4.t) Conduit_mirage_tcp.endpoint * Tls.Config.client, TCP.protocol Conduit_mirage_tls.protocol_with_tls) Conduit_mirage.protocol
-  val tls_service : (StackV4.t Conduit_mirage_tcp.configuration * Tls.Config.server,
-                     TCP.service Conduit_mirage_tls.service_with_tls,
-                     TCP.protocol Conduit_mirage_tls.protocol_with_tls) Conduit_mirage.Service.service
+  val tls_protocol :
+    ( (StackV4.t, Ipaddr.V4.t) Conduit_mirage_tcp.endpoint * Tls.Config.client,
+      TCP.protocol Conduit_mirage_tls.protocol_with_tls )
+    Conduit_mirage.protocol
 
-  exception Send_error  of string
-  exception Recv_error  of string
+  val tls_service :
+    ( StackV4.t Conduit_mirage_tcp.configuration * Tls.Config.server,
+      TCP.service Conduit_mirage_tls.service_with_tls,
+      TCP.protocol Conduit_mirage_tls.protocol_with_tls )
+    Conduit_mirage.Service.service
+
+  exception Send_error of string
+
+  exception Recv_error of string
+
   exception Close_error of string
 
-  val http
-    :  ?config:Httpaf.Config.t
-    -> error_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.error_handler)
-    -> request_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.request_handler)
-    -> TCP.service
-    -> (unit, [> Conduit_mirage.error ]) result Lwt.t
+  val http :
+    ?config:Httpaf.Config.t ->
+    error_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.error_handler) ->
+    request_handler:
+      (Ipaddr.V4.t * int -> Httpaf.Server_connection.request_handler) ->
+    TCP.service ->
+    (unit, [> Conduit_mirage.error ]) result Lwt.t
 
-  val https
-    :  ?config:Httpaf.Config.t
-    -> error_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.error_handler)
-    -> request_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.request_handler)
-    -> TCP.service Conduit_mirage_tls.service_with_tls
-    -> (unit, [> Conduit_mirage.error ]) result Lwt.t
+  val https :
+    ?config:Httpaf.Config.t ->
+    error_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.error_handler) ->
+    request_handler:
+      (Ipaddr.V4.t * int -> Httpaf.Server_connection.request_handler) ->
+    TCP.service Conduit_mirage_tls.service_with_tls ->
+    (unit, [> Conduit_mirage.error ]) result Lwt.t
 
-  val request
-    :  ?config:Httpaf.Config.t
-    -> resolvers:Conduit.resolvers
-    -> error_handler:(Conduit_mirage.flow -> (Ipaddr.V4.t * int) option -> Httpaf.Client_connection.error_handler)
-    -> response_handler:((Ipaddr.V4.t * int) option -> Httpaf.Client_connection.response_handler)
-    -> [ `host ] Domain_name.t
-    -> Httpaf.Request.t
-    -> ([ `write ] Httpaf.Body.t, [> Conduit_mirage.error ]) result Lwt.t
+  val request :
+    ?config:Httpaf.Config.t ->
+    resolvers:Conduit.resolvers ->
+    error_handler:
+      (Conduit_mirage.flow ->
+      (Ipaddr.V4.t * int) option ->
+      Httpaf.Client_connection.error_handler) ->
+    response_handler:
+      ((Ipaddr.V4.t * int) option -> Httpaf.Client_connection.response_handler) ->
+    [ `host ] Domain_name.t ->
+    Httpaf.Request.t ->
+    ([ `write ] Httpaf.Body.t, [> Conduit_mirage.error ]) result Lwt.t
 end

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,27 +1,23 @@
-open Conduit_mirage
-open Conduit_mirage_tls
+module Conduit_mirage_tls : module type of Conduit_tls.Make (Lwt) (Conduit_mirage)
 
 module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
   module TCP : module type of Conduit_mirage_tcp.Make(StackV4)
+
+  val tls_protocol : ((StackV4.t, Ipaddr.V4.t) Conduit_mirage_tcp.endpoint * Tls.Config.client, TCP.protocol Conduit_mirage_tls.protocol_with_tls) Conduit_mirage.protocol
+  val tls_service : (StackV4.t Conduit_mirage_tcp.configuration * Tls.Config.server,
+                     TCP.service Conduit_mirage_tls.service_with_tls,
+                     TCP.protocol Conduit_mirage_tls.protocol_with_tls) Conduit_mirage.Service.service
 
   exception Send_error  of string
   exception Recv_error  of string
   exception Close_error of string
 
-  type tcp_endpoint = (StackV4.t, Ipaddr.V4.t) Conduit_mirage_tcp.endpoint
-  type tcp_configuration = StackV4.t Conduit_mirage_tcp.configuration
-
-  val tls_endpoint : (tcp_endpoint * Tls.Config.client) key
-  val tls_configuration : (tcp_configuration * Tls.Config.server) key
-
-  val tls_protocol : TCP.protocol protocol_with_tls Witness.protocol
-  val tls_service : (TCP.service service_with_tls * TCP.protocol protocol_with_tls) Witness.service
-
   val http
     :  ?config:Httpaf.Config.t
     -> error_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.error_handler)
     -> request_handler:(Ipaddr.V4.t * int -> Httpaf.Server_connection.request_handler)
-    -> TCP.service -> (unit, [> Conduit_mirage.error ]) result Lwt.t
+    -> TCP.service
+    -> (unit, [> Conduit_mirage.error ]) result Lwt.t
 
   val https
     :  ?config:Httpaf.Config.t
@@ -31,8 +27,7 @@ module Make (Time : Mirage_time.S) (StackV4 : Mirage_stack.V4) : sig
     -> (unit, [> Conduit_mirage.error ]) result Lwt.t
 
   val request
-    :  ?key:'a key
-    -> ?config:Httpaf.Config.t
+    :  ?config:Httpaf.Config.t
     -> resolvers:Conduit.resolvers
     -> error_handler:(Conduit_mirage.flow -> (Ipaddr.V4.t * int) option -> Httpaf.Client_connection.error_handler)
     -> response_handler:((Ipaddr.V4.t * int) option -> Httpaf.Client_connection.response_handler)

--- a/paf.opam
+++ b/paf.opam
@@ -13,9 +13,9 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 pin-depends: [
-  [ "conduit.dev" "https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
-  [ "conduit-tls.dev" "https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
-  [ "conduit-mirage.dev" "https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
+  [ "conduit.dev" "git+https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
+  [ "conduit-tls.dev" "git+https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
+  [ "conduit-mirage.dev" "git+https://github.com/dinosaure/ocaml-conduit.git#3.0.0" ]
 ]
 
 depends: [

--- a/paf.opam
+++ b/paf.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name:         "tuyau"
+name:         "paf"
 maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
 authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
 homepage:     "https://github.com/dinosaure/paf-le-chien"
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/dinosaure/paf-le-chien/issues"
 dev-repo:     "git+https://github.com/dinosaure/paf-le-chien.git"
 doc:          "https://dinosaure.github.io/paf-le-chien/"
 license:      "MIT"
-synopsis:     "HTTP/AF port to MirageOS and tuyau"
+synopsis:     "HTTP/AF port to MirageOS and conduit"
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
@@ -24,6 +24,7 @@ depends: [
   "conduit"        {pinned}
   "conduit-tls"    {pinned}
   "conduit-mirage" {pinned}
+  "mirage-stack"
   "mirage-time"
   "httpaf"
   "ke"

--- a/test/dune
+++ b/test/dune
@@ -1,9 +1,11 @@
 (executable
  (name simple_server)
  (modules simple_server)
- (libraries logs.fmt fmt.tty mirage-crypto-rng.unix mirage-time-unix tcpip.stack-socket paf))
+ (libraries logs.fmt fmt.tty mirage-crypto-rng.unix mirage-time-unix
+   tcpip.stack-socket paf))
 
 (executable
  (name simple_client)
  (modules simple_client)
- (libraries ptime.clock.os logs.fmt fmt.tty uri mirage-crypto-rng.unix mirage-time-unix tcpip.stack-socket paf))
+ (libraries ptime.clock.os logs.fmt fmt.tty uri mirage-crypto-rng.unix
+   mirage-time-unix tcpip.stack-socket paf))

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -6,7 +6,7 @@ let reporter ppf =
         Logs_fmt.pp_header (level, header)
         Fmt.(styled `Magenta string) (Logs.Src.name src) in
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
-  { Logs.report } 
+  { Logs.report }
 
 let () = Mirage_crypto_rng_unix.initialize ()
 let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
@@ -104,8 +104,8 @@ let run uri =
     let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
     let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
     let response_handler = response_handler th_err ~f in
-    let resolvers = Conduit_mirage.register_resolver ~key:Paf.tls_endpoint (https_resolver ?port stack) Conduit.empty in
-    Paf.request ~key:Paf.tls_endpoint
+    let resolvers = Conduit_mirage.add Paf.tls_protocol (https_resolver ?port stack) Conduit.empty in
+    Paf.request
       ~resolvers
       ~error_handler:(error_handler wk_err)
       ~response_handler
@@ -120,8 +120,8 @@ let run uri =
     let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
     let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
     let response_handler = response_handler th_err ~f in
-    let resolvers = Conduit_mirage.register_resolver ~key:Paf.TCP.endpoint (http_resolver ?port stack) Conduit.empty in
-    Paf.request ~key:Paf.TCP.endpoint
+    let resolvers = Conduit_mirage.add Paf.TCP.protocol (http_resolver ?port stack) Conduit.empty in
+    Paf.request
       ~resolvers
       ~error_handler:(error_handler wk_err)
       ~response_handler

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -1,29 +1,34 @@
 let reporter ppf =
   let report src level ~over k msgf =
-    let k _ = over () ; k () in
+    let k _ =
+      over () ;
+      k () in
     let with_metadata header _tags k ppf fmt =
-      Format.kfprintf k ppf ("%a[%a]: " ^^ fmt ^^ "\n%!")
+      Format.kfprintf k ppf
+        ("%a[%a]: " ^^ fmt ^^ "\n%!")
         Logs_fmt.pp_header (level, header)
-        Fmt.(styled `Magenta string) (Logs.Src.name src) in
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
   { Logs.report }
 
 let () = Mirage_crypto_rng_unix.initialize ()
+
 let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+
 let () = Logs.set_reporter (reporter Fmt.stderr)
+
 let () = Logs.set_level ~all:true (Some Logs.Debug)
 
 let failwith fmt = Format.kasprintf (fun err -> Lwt.fail (Failure err)) fmt
 
-module Paf = Paf.Make(Time)(Tcpip_stack_socket)
-
+module Paf = Paf.Make (Time) (Tcpip_stack_socket)
 open Lwt.Infix
 
-let ( >>? ) x f = x >>= function
-  | Ok x -> f x
-  | Error err -> Lwt.return_error err
+let ( >>? ) x f =
+  x >>= function Ok x -> f x | Error err -> Lwt.return_error err
 
-let ( <.> ) f g = fun x -> f (g x)
+let ( <.> ) f g x = f (g x)
 
 let response_handler th_err ~f _ response body =
   let buf = Buffer.create 0x100 in
@@ -38,53 +43,56 @@ let response_handler th_err ~f _ response body =
     Httpaf.Body.schedule_read body ~on_eof ~on_read in
   Httpaf.Body.schedule_read body ~on_eof ~on_read ;
   Lwt.async @@ fun () ->
-  Lwt.pick
-    [ (th >|= fun () -> `Done)
-    ; th_err ] >>= function
+  Lwt.pick [ (th >|= fun () -> `Done); th_err ] >>= function
   | `Done -> f response (Buffer.contents buf)
   | _ -> Lwt.return_unit
 
 let failf fmt = Format.kasprintf (fun err -> raise (Failure err)) fmt
 
 let error_handler wk _ _ err =
-  Lwt.wakeup_later wk (err :> [ `Body of string | `Done | Httpaf.Client_connection.error ]);
+  Lwt.wakeup_later wk
+    (err :> [ `Body of string | `Done | Httpaf.Client_connection.error ]) ;
   Format.eprintf "Got an error while sending request.\n%!" ;
   match err with
   | `Exn (Paf.Send_error err)
   | `Exn (Paf.Recv_error err)
   | `Exn (Paf.Close_error err) ->
-    failf "Impossible to start a transmission: %s" err
-  | `Invalid_response_body_length _ ->
-    failf "Invalid response body-length"
-  | `Malformed_response _ ->
-    failf "Malformed response"
+      failf "Impossible to start a transmission: %s" err
+  | `Invalid_response_body_length _ -> failf "Invalid response body-length"
+  | `Malformed_response _ -> failf "Malformed response"
   | `Exn _exn -> ()
 
-let http_resolver stack ?(port= 80) domain_name =
+let http_resolver stack ?(port = 80) domain_name =
   Lwt_unix.gethostbyname (Domain_name.to_string domain_name) >>= function
   | { Unix.h_addr_list; _ } when Array.length h_addr_list > 0 ->
-    Lwt.return_some { Conduit_mirage_tcp.stack
-                    ; keepalive= None
-                    ; nodelay= false
-                    ; ip= Ipaddr_unix.V4.of_inet_addr_exn h_addr_list.(0)
-                    ; port }
+      Lwt.return_some
+        {
+          Conduit_mirage_tcp.stack;
+          keepalive = None;
+          nodelay = false;
+          ip = Ipaddr_unix.V4.of_inet_addr_exn h_addr_list.(0);
+          port;
+        }
   | _ -> Lwt.return_none
 
 let anchors = []
 
 let authenticator _expect ~host crts =
   let crts = X509.Validation.valid_cas crts in
-  match X509.Validation.verify_chain
-         ~host ~time:(fun () -> Some (Ptime_clock.now ()))
-         ~anchors crts with
+  match
+    X509.Validation.verify_chain ~host
+      ~time:(fun () -> Some (Ptime_clock.now ()))
+      ~anchors crts
+  with
   | Ok crt -> Ok (Some ([], crt))
   | Error _ -> Ok None
 
-let https_resolver stack ?(port= 443) domain_name =
+let https_resolver stack ?(port = 443) domain_name =
   http_resolver stack domain_name >>= function
   | Some config ->
-    let tls_config = Tls.Config.client ~authenticator:(authenticator domain_name) () in
-    Lwt.return_some ({ config with port }, tls_config)
+      let tls_config =
+        Tls.Config.client ~authenticator:(authenticator domain_name) () in
+      Lwt.return_some ({ config with port }, tls_config)
   | None -> Lwt.return_none
 
 let stack ip =
@@ -96,47 +104,54 @@ let run uri =
   stack Ipaddr.V4.localhost >>= fun stack ->
   let th, wk = Lwt.wait () in
   let port = Uri.port uri in
-  let f _ body = Lwt.wakeup_later wk body ; Lwt.return () in
-  let th_err, (wk_err : [ `Body of string | `Done | Httpaf.Client_connection.error ] Lwt.u) = Lwt.wait () in
-  match Uri.scheme uri, Uri.host uri with
-  | Some "https", Some hostname ->
-    let headers = Httpaf.Headers.of_list [ "Host", hostname ] in
-    let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
-    let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
-    let response_handler = response_handler th_err ~f in
-    let resolvers = Conduit_mirage.add Paf.tls_protocol (https_resolver ?port stack) Conduit.empty in
-    Paf.request
-      ~resolvers
-      ~error_handler:(error_handler wk_err)
-      ~response_handler
-      hostname request >>? fun body ->
-    Httpaf.Body.close_writer body ;
-    ( Lwt.pick [ (th >|= fun body -> `Body body)
-               ; th_err ] >>= function
+  let f _ body =
+    Lwt.wakeup_later wk body ;
+    Lwt.return () in
+  let ( th_err,
+        (wk_err :
+          [ `Body of string | `Done | Httpaf.Client_connection.error ] Lwt.u) )
+      =
+    Lwt.wait () in
+  match (Uri.scheme uri, Uri.host uri) with
+  | Some "https", Some hostname -> (
+      let headers = Httpaf.Headers.of_list [ ("Host", hostname) ] in
+      let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
+      let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
+      let response_handler = response_handler th_err ~f in
+      let resolvers =
+        Conduit_mirage.add Paf.tls_protocol
+          (https_resolver ?port stack)
+          Conduit.empty in
+      Paf.request ~resolvers ~error_handler:(error_handler wk_err)
+        ~response_handler hostname request
+      >>? fun body ->
+      Httpaf.Body.close_writer body ;
+      Lwt.pick [ (th >|= fun body -> `Body body); th_err ] >>= function
       | `Body body -> Lwt.return_ok body
-      | _ -> Lwt.return_error (`Msg "Got an error while sending request") )
-  | Some "http", Some hostname ->
-    let headers = Httpaf.Headers.of_list [ "Host", hostname ] in
-    let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
-    let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
-    let response_handler = response_handler th_err ~f in
-    let resolvers = Conduit_mirage.add Paf.TCP.protocol (http_resolver ?port stack) Conduit.empty in
-    Paf.request
-      ~resolvers
-      ~error_handler:(error_handler wk_err)
-      ~response_handler
-      hostname request >>? fun body ->
-    Httpaf.Body.close_writer body ;
-    ( Lwt.pick [ (th >|= fun body -> `Body body)
-               ; th_err ] >>= function
+      | _ -> Lwt.return_error (`Msg "Got an error while sending request"))
+  | Some "http", Some hostname -> (
+      let headers = Httpaf.Headers.of_list [ ("Host", hostname) ] in
+      let hostname = Domain_name.(host_exn <.> of_string_exn) hostname in
+      let request = Httpaf.Request.create ~headers `GET (Uri.path uri) in
+      let response_handler = response_handler th_err ~f in
+      let resolvers =
+        Conduit_mirage.add Paf.TCP.protocol
+          (http_resolver ?port stack)
+          Conduit.empty in
+      Paf.request ~resolvers ~error_handler:(error_handler wk_err)
+        ~response_handler hostname request
+      >>? fun body ->
+      Httpaf.Body.close_writer body ;
+      Lwt.pick [ (th >|= fun body -> `Body body); th_err ] >>= function
       | `Body body -> Lwt.return_ok body
-      | _ -> Lwt.return_error (`Msg "Got an error while sending request") )
+      | _ -> Lwt.return_error (`Msg "Got an error while sending request"))
   | _, _ -> failwith "Invalid uri: %a" Uri.pp uri
 
-let () = match Sys.argv with
-  | [| _; uri; |] ->
-    ( match Lwt_main.run (run (Uri.of_string uri)) with
-    | Ok body -> print_string body
-    | Error err -> Format.eprintf "%s: %a\n%!" Sys.argv.(0) Conduit_mirage.pp_error err )
-  | _ ->
-    Format.eprintf "%s <uri>\n%!" Sys.argv.(0)
+let () =
+  match Sys.argv with
+  | [| _; uri |] -> (
+      match Lwt_main.run (run (Uri.of_string uri)) with
+      | Ok body -> print_string body
+      | Error err ->
+          Format.eprintf "%s: %a\n%!" Sys.argv.(0) Conduit_mirage.pp_error err)
+  | _ -> Format.eprintf "%s <uri>\n%!" Sys.argv.(0)

--- a/test/simple_server.ml
+++ b/test/simple_server.ml
@@ -1,12 +1,16 @@
 let reporter ppf =
   let report src level ~over k msgf =
-    let k _ = over () ; k () in
+    let k _ =
+      over () ;
+      k () in
     let with_metadata header _tags k ppf fmt =
-      Format.kfprintf k ppf ("%a[%a]: " ^^ fmt ^^ "\n%!")
+      Format.kfprintf k ppf
+        ("%a[%a]: " ^^ fmt ^^ "\n%!")
         Logs_fmt.pp_header (level, header)
-        Fmt.(styled `Magenta string) (Logs.Src.name src) in
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
-  { Logs.report } 
+  { Logs.report }
 
 let sigpipe = 13
 
@@ -20,22 +24,26 @@ let () = Logs.set_level ~all:true (Some Logs.Debug)
 
 let () = Sys.set_signal sigpipe Sys.Signal_ignore
 
-module Paf = Paf.Make(Time)(Tcpip_stack_socket)
+module Paf = Paf.Make (Time) (Tcpip_stack_socket)
 module Ke = Ke.Rke
 
 let getline queue =
   let exists ~predicate queue =
     let pos = ref 0 and res = ref (-1) in
-    Ke.iter (fun chr -> if predicate chr then res := !pos ; incr pos) queue ;
+    Ke.iter
+      (fun chr ->
+        if predicate chr then res := !pos ;
+        incr pos)
+      queue ;
     if !res = -1 then None else Some !res in
   let blit src src_off dst dst_off len =
     Bigstringaf.blit_to_bytes src ~src_off dst ~dst_off ~len in
-  match exists ~predicate:((=) '\n') queue with
+  match exists ~predicate:(( = ) '\n') queue with
   | Some pos ->
-    let tmp = Bytes.create pos in
-    Ke.N.keep_exn queue ~blit ~length:Bytes.length ~off:0 ~len:pos tmp ;
-    Ke.N.shift_exn queue (pos + 1) ;
-    Some (Bytes.unsafe_to_string tmp)
+      let tmp = Bytes.create pos in
+      Ke.N.keep_exn queue ~blit ~length:Bytes.length ~off:0 ~len:pos tmp ;
+      Ke.N.shift_exn queue (pos + 1) ;
+      Some (Bytes.unsafe_to_string tmp)
   | None -> None
 
 let http_large filename (ip, port) ic oc =
@@ -44,12 +52,15 @@ let http_large filename (ip, port) ic oc =
   Body.close_reader ic ;
   let ic = open_in filename in
   let tp = Bytes.create 0x1000 in
-  let rec go () = match input ic tp 0 (Bytes.length tp) with
+  let rec go () =
+    match input ic tp 0 (Bytes.length tp) with
     | 0 -> Body.close_writer oc
     | len ->
-      Body.write_string oc (Bytes.sub_string tp 0 len) ; go ()
+        Body.write_string oc (Bytes.sub_string tp 0 len) ;
+        go ()
     | exception End_of_file -> Body.close_writer oc in
-  go () ; close_in ic
+  go () ;
+  close_in ic
 
 let http_ping_pong (ip, port) ic oc =
   let open Httpaf in
@@ -64,18 +75,23 @@ let http_ping_pong (ip, port) ic oc =
     Ke.N.push queue ~blit ~length:Bigstringaf.length buf ~off ~len ;
     Body.schedule_read ic ~on_eof ~on_read in
   Body.schedule_read ic ~on_eof ~on_read ;
-  let rec go () = match !closed, getline queue with
+  let rec go () =
+    match (!closed, getline queue) with
     | false, None -> Lwt.pause () >>= go
     | false, Some "ping" ->
-      Body.write_string oc "pong\n" ; go ()
+        Body.write_string oc "pong\n" ;
+        go ()
     | false, Some "pong" ->
-      Body.write_string oc "ping\n" ; go ()
+        Body.write_string oc "ping\n" ;
+        go ()
     | false, Some line ->
-      Fmt.pr "<%a:%d> gaves a wrong line: %S.\n%!" Ipaddr.V4.pp ip port line ;
-      Body.close_writer oc ; Lwt.return_unit
+        Fmt.pr "<%a:%d> gaves a wrong line: %S.\n%!" Ipaddr.V4.pp ip port line ;
+        Body.close_writer oc ;
+        Lwt.return_unit
     | true, _ ->
-      Fmt.pr "<%a:%d> closed the connection.\n%!" Ipaddr.V4.pp ip port ;
-      Body.close_writer oc ; Lwt.return_unit in
+        Fmt.pr "<%a:%d> closed the connection.\n%!" Ipaddr.V4.pp ip port ;
+        Body.close_writer oc ;
+        Lwt.return_unit in
   Lwt.async go
 
 let request_handler large (ip, port) reqd =
@@ -83,58 +99,58 @@ let request_handler large (ip, port) reqd =
   let request = Reqd.request reqd in
   match request.Request.target with
   | "/" ->
-    Fmt.epr ">>> start a keep-alive connection.\n%!" ;
-    let headers = Headers.of_list [ "transfer-encoding", "chunked" ] in
-    let response = Response.create ~headers `OK in
-    let oc = Reqd.respond_with_streaming reqd response in
-    http_ping_pong (ip, port) (Reqd.request_body reqd) oc
+      Fmt.epr ">>> start a keep-alive connection.\n%!" ;
+      let headers = Headers.of_list [ ("transfer-encoding", "chunked") ] in
+      let response = Response.create ~headers `OK in
+      let oc = Reqd.respond_with_streaming reqd response in
+      http_ping_pong (ip, port) (Reqd.request_body reqd) oc
   | "/ping" ->
-    let headers = Headers.of_list [ "content-length", "4" ] in
-    let response = Response.create ~headers `OK in
-    Reqd.respond_with_string reqd response "pong"
+      let headers = Headers.of_list [ ("content-length", "4") ] in
+      let response = Response.create ~headers `OK in
+      Reqd.respond_with_string reqd response "pong"
   | "/pong" ->
-    let headers = Headers.of_list [ "content-length", "4" ] in
-    let response = Response.create ~headers `OK in
-    Reqd.respond_with_string reqd response "ping"
+      let headers = Headers.of_list [ ("content-length", "4") ] in
+      let response = Response.create ~headers `OK in
+      Reqd.respond_with_string reqd response "ping"
   | "/large" ->
-    let headers = Headers.of_list [ "transfer-encoding", "chunked" ] in
-    let response = Response.create ~headers `OK in
-    let oc = Reqd.respond_with_streaming reqd response in
-    http_large large (ip, port) (Reqd.request_body reqd) oc
+      let headers = Headers.of_list [ ("transfer-encoding", "chunked") ] in
+      let response = Response.create ~headers `OK in
+      let oc = Reqd.respond_with_streaming reqd response in
+      http_large large (ip, port) (Reqd.request_body reqd) oc
   | _ -> assert false
 
 let error_handler (ip, port) ?request:_ error respond =
-  let open Httpaf in match error with
+  let open Httpaf in
+  match error with
   | `Exn (Paf.Send_error err)
   | `Exn (Paf.Recv_error err)
   | `Exn (Paf.Close_error err) ->
-    let contents = Fmt.strf "Internal server error from <%a:%d>: %s" Ipaddr.V4.pp ip port err in
-    let headers  = Headers.of_list
-        [ "content-length", string_of_int (String.length contents) ] in
-    let body = respond headers in
-    Body.write_string body contents ;
-    Body.close_writer body
+      let contents =
+        Fmt.strf "Internal server error from <%a:%d>: %s" Ipaddr.V4.pp ip port
+          err in
+      let headers =
+        Headers.of_list
+          [ ("content-length", string_of_int (String.length contents)) ] in
+      let body = respond headers in
+      Body.write_string body contents ;
+      Body.close_writer body
   | `Exn exn ->
-    Fmt.epr "Got an exception: %s.\n%!" (Printexc.to_string exn) ;
-    Printexc.print_backtrace stderr
-  | `Bad_gateway ->
-    Fmt.epr "Got a bad gateway error.\n%!"
-  | `Bad_request ->
-    Fmt.epr "Got a bad request error.\n%!"
-  | `Internal_server_error ->
-    Fmt.epr "Got an internal server error.\n%!" ;
+      Fmt.epr "Got an exception: %s.\n%!" (Printexc.to_string exn) ;
+      Printexc.print_backtrace stderr
+  | `Bad_gateway -> Fmt.epr "Got a bad gateway error.\n%!"
+  | `Bad_request -> Fmt.epr "Got a bad request error.\n%!"
+  | `Internal_server_error -> Fmt.epr "Got an internal server error.\n%!"
 
 open Lwt.Infix
 
-let ( >>? ) x f = x >>= function
-  | Ok x -> f x
-  | Error _ as err -> Lwt.return err
+let ( >>? ) x f =
+  x >>= function Ok x -> f x | Error _ as err -> Lwt.return err
 
 let server_http large stack =
   Conduit_mirage.Service.init
-    { Conduit_mirage_tcp.stack; keepalive= None; nodelay= false
-    ; port= 8080; }
-    ~service:Paf.TCP.service >>? fun master ->
+    { Conduit_mirage_tcp.stack; keepalive = None; nodelay = false; port = 8080 }
+    ~service:Paf.TCP.service
+  >>? fun master ->
   Paf.http ~error_handler ~request_handler:(request_handler large) master
 
 let load_file filename =
@@ -142,20 +158,28 @@ let load_file filename =
   let ln = in_channel_length ic in
   let rs = Bytes.create ln in
   really_input ic rs 0 ln ;
-  close_in ic ; Cstruct.of_bytes rs
+  close_in ic ;
+  Cstruct.of_bytes rs
 
 let server_https cert key large stack =
   let cert = load_file cert in
-  let key  = load_file key in
-  match X509.Certificate.decode_pem_multiple cert,
-        X509.Private_key.decode_pem key with
+  let key = load_file key in
+  match
+    (X509.Certificate.decode_pem_multiple cert, X509.Private_key.decode_pem key)
+  with
   | Ok certs, Ok (`RSA key) ->
-    let config = Tls.Config.server ~certificates:(`Single (certs, key)) () in
-    Conduit_mirage.Service.init
-      ({ Conduit_mirage_tcp.stack; keepalive= None; nodelay= false
-       ; port= 4343; }, config)
-      ~service:Paf.tls_service >>? fun master ->
-    Paf.https ~error_handler ~request_handler:(request_handler large) master
+      let config = Tls.Config.server ~certificates:(`Single (certs, key)) () in
+      Conduit_mirage.Service.init
+        ( {
+            Conduit_mirage_tcp.stack;
+            keepalive = None;
+            nodelay = false;
+            port = 4343;
+          },
+          config )
+        ~service:Paf.tls_service
+      >>? fun master ->
+      Paf.https ~error_handler ~request_handler:(request_handler large) master
   | _ -> invalid_arg "Invalid certificate or key"
 
 let stack ip =
@@ -168,21 +192,19 @@ let run_http large =
   server_http large stack >>= function
   | Ok () -> Lwt.return_unit
   | Error err ->
-    Fmt.epr "error: %a.\n%!" Conduit_mirage.pp_error err ;
-    Lwt.return_unit
+      Fmt.epr "error: %a.\n%!" Conduit_mirage.pp_error err ;
+      Lwt.return_unit
 
 let run_https cert key large =
-  stack Ipaddr.V4.localhost >>=
-  server_https cert key large >>= function
+  stack Ipaddr.V4.localhost >>= server_https cert key large >>= function
   | Ok () -> Lwt.return_unit
   | Error err ->
-    Fmt.epr "error: %a.\n%!" Conduit_mirage.pp_error err ;
-    Lwt.return_unit
+      Fmt.epr "error: %a.\n%!" Conduit_mirage.pp_error err ;
+      Lwt.return_unit
 
-let () = match Sys.argv with
-  | [| _; "--with-tls"; cert; key; large; |] ->
-    Lwt_main.run (run_https cert key large)
-  | [| _; large; |] ->
-    Lwt_main.run (run_http large)
-  | _ ->
-    Fmt.epr "%s [--with-tls cert key] large\n%!" Sys.argv.(0)
+let () =
+  match Sys.argv with
+  | [| _; "--with-tls"; cert; key; large |] ->
+      Lwt_main.run (run_https cert key large)
+  | [| _; large |] -> Lwt_main.run (run_http large)
+  | _ -> Fmt.epr "%s [--with-tls cert key] large\n%!" Sys.argv.(0)


### PR DESCRIPTION
So, after some fix about `conduit` and others parts of the HTTP stack, I think this is the final version of `paf`. We should add tests however (and correctly use `simple_client` and `simple_server`). The library was tested with the UNIX TCP/IP stack mainly __and__ the `mirage-tcpip` stack with Solo5 and it seems to work properly (from what I know).