### PR TITLE
Add a CoHTTP Client compatible layer and a let's encrypt provider

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -12,6 +12,7 @@
 
 (library
  (name le)
+ (wrapped false)
  (public_name paf.le)
  (modules lE)
  (libraries paf.cohttp emile letsencrypt))

--- a/lib/dune
+++ b/lib/dune
@@ -4,6 +4,18 @@
  (modules paf)
  (libraries tls-mirage mirage-time mirage-stack ke httpaf mimic))
 
+(library
+ (name paf_cohttp)
+ (public_name paf.cohttp)
+ (modules paf_cohttp)
+ (libraries paf cohttp-lwt))
+
+(library
+ (name le)
+ (public_name paf.le)
+ (modules lE)
+ (libraries paf.cohttp emile letsencrypt))
+
 ; (library
 ;  (name mirage_paf)
 ;  (public_name paf.mirage)

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -66,4 +66,6 @@ module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) = struct
     let solver = Letsencrypt.Client.http_solver solver in
     Acme.sign_certificate ~ctx solver le sleep csr >|= fun certs ->
     `Single (certs, priv)
+
+  include Client
 end

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -1,0 +1,69 @@
+(* (c) Hannes Menhert *)
+
+module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) = struct
+  module Client = Paf_cohttp.Make(Paf)
+  module Acme = Letsencrypt.Client.Make(Client)
+  module Log = (val let src = Logs.Src.create "letsencrypt" in
+                Logs.src_log src : Logs.LOG)
+
+  type configuration =
+    { email : Emile.mailbox option
+    ; seed : string option
+    ; certificate_seed : string option
+    ; hostname : [ `host ] Domain_name.t }
+
+  let gen_rsa ?seed () =
+    let g = match seed with
+      | None -> None
+      | Some seed ->
+        let seed = Cstruct.of_string seed in
+        Some (Mirage_crypto_rng.(create ~seed (module Fortuna))) in
+    Mirage_crypto_pk.Rsa.generate ?g ~bits:4096 ()
+
+  let csr seed hostname =
+    let hostname = Domain_name.to_string hostname in
+    let cn = X509.[Distinguished_name.(Relative_distinguished_name.singleton (CN hostname))]
+    and key = gen_rsa ?seed () in
+    key, X509.Signing_request.create cn (`RSA key)
+
+  let prefix = ".well-known", "acme-challenge"
+  let tokens = Hashtbl.create 1
+
+  let solver _host ~prefix:_ ~token ~content =
+    Hashtbl.replace tokens token content;
+    Lwt.return (Ok ())
+
+  let request_handler (ipaddr, port) reqd =
+    Log.debug (fun m -> m "Let's encrypt request handler for %a:%d" Ipaddr.pp ipaddr port) ;
+    let req = Httpaf.Reqd.request reqd in
+    match Astring.String.cuts ~sep:"/" ~empty:false req.Httpaf.Request.target with
+    | [ p1; p2; token; ]
+      when String.equal p1 (fst prefix) && String.equal p2 (snd prefix) ->
+      ( match Hashtbl.find tokens token with
+        | data ->
+          let headers = Httpaf.Headers.of_list [ "content-type", "application/octet-stream"
+                                               ; "content-length", string_of_int (String.length data) ] in
+          let resp = Httpaf.Response.create ~headers `OK in
+          Httpaf.Reqd.respond_with_string reqd resp data
+        | exception Not_found ->
+          let headers = Httpaf.Headers.of_list [ "connection", "close" ] in
+          let resp = Httpaf.Response.create ~headers `Not_found in
+          Httpaf.Reqd.respond_with_string reqd resp "" )
+    | _ ->
+      let headers = Httpaf.Headers.of_list [ "connection", "close" ] in
+      let resp = Httpaf.Response.create ~headers `Not_found in
+      Httpaf.Reqd.respond_with_string reqd resp ""
+
+  let provision_certificate ?(production= false) cfg ctx =
+    let open Lwt_result.Infix in
+    let endpoint =
+      if production then Letsencrypt.letsencrypt_production_url
+      else Letsencrypt.letsencrypt_staging_url in
+    Acme.initialise ~ctx ~endpoint ?email:(Option.map Emile.to_string cfg.email)
+      (gen_rsa ?seed:cfg.seed ()) >>= fun le ->
+    let sleep sec = Time.sleep_ns (Duration.of_sec sec) in
+    let priv, csr = csr cfg.certificate_seed cfg.hostname in
+    let solver = Letsencrypt.Client.http_solver solver in
+    Acme.sign_certificate ~ctx solver le sleep csr >|= fun certs ->
+    `Single (certs, priv)
+end

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -1,66 +1,85 @@
 (* (c) Hannes Menhert *)
 
 module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) = struct
-  module Client = Paf_cohttp.Make(Paf)
-  module Acme = Letsencrypt.Client.Make(Client)
-  module Log = (val let src = Logs.Src.create "letsencrypt" in
-                Logs.src_log src : Logs.LOG)
+  module Client = Paf_cohttp.Make (Paf)
+  module Acme = Letsencrypt.Client.Make (Client)
 
-  type configuration =
-    { email : Emile.mailbox option
-    ; seed : string option
-    ; certificate_seed : string option
-    ; hostname : [ `host ] Domain_name.t }
+  module Log = (val let src = Logs.Src.create "letsencrypt" in
+                    Logs.src_log src : Logs.LOG)
+
+  type configuration = {
+    email : Emile.mailbox option;
+    seed : string option;
+    certificate_seed : string option;
+    hostname : [ `host ] Domain_name.t;
+  }
 
   let gen_rsa ?seed () =
-    let g = match seed with
+    let g =
+      match seed with
       | None -> None
       | Some seed ->
-        let seed = Cstruct.of_string seed in
-        Some (Mirage_crypto_rng.(create ~seed (module Fortuna))) in
+          let seed = Cstruct.of_string seed in
+          Some Mirage_crypto_rng.(create ~seed (module Fortuna)) in
     Mirage_crypto_pk.Rsa.generate ?g ~bits:4096 ()
 
   let csr seed hostname =
     let hostname = Domain_name.to_string hostname in
-    let cn = X509.[Distinguished_name.(Relative_distinguished_name.singleton (CN hostname))]
+    let cn =
+      X509.
+        [
+          Distinguished_name.(
+            Relative_distinguished_name.singleton (CN hostname));
+        ]
     and key = gen_rsa ?seed () in
-    key, X509.Signing_request.create cn (`RSA key)
+    (key, X509.Signing_request.create cn (`RSA key))
 
-  let prefix = ".well-known", "acme-challenge"
+  let prefix = (".well-known", "acme-challenge")
+
   let tokens = Hashtbl.create 1
 
   let solver _host ~prefix:_ ~token ~content =
-    Hashtbl.replace tokens token content;
+    Hashtbl.replace tokens token content ;
     Lwt.return (Ok ())
 
   let request_handler (ipaddr, port) reqd =
-    Log.debug (fun m -> m "Let's encrypt request handler for %a:%d" Ipaddr.pp ipaddr port) ;
+    Log.debug (fun m ->
+        m "Let's encrypt request handler for %a:%d" Ipaddr.pp ipaddr port) ;
     let req = Httpaf.Reqd.request reqd in
-    match Astring.String.cuts ~sep:"/" ~empty:false req.Httpaf.Request.target with
-    | [ p1; p2; token; ]
-      when String.equal p1 (fst prefix) && String.equal p2 (snd prefix) ->
-      ( match Hashtbl.find tokens token with
+    match
+      Astring.String.cuts ~sep:"/" ~empty:false req.Httpaf.Request.target
+    with
+    | [ p1; p2; token ]
+      when String.equal p1 (fst prefix) && String.equal p2 (snd prefix) -> (
+        match Hashtbl.find tokens token with
         | data ->
-          let headers = Httpaf.Headers.of_list [ "content-type", "application/octet-stream"
-                                               ; "content-length", string_of_int (String.length data) ] in
-          let resp = Httpaf.Response.create ~headers `OK in
-          Httpaf.Reqd.respond_with_string reqd resp data
+            let headers =
+              Httpaf.Headers.of_list
+                [
+                  ("content-type", "application/octet-stream");
+                  ("content-length", string_of_int (String.length data));
+                ] in
+            let resp = Httpaf.Response.create ~headers `OK in
+            Httpaf.Reqd.respond_with_string reqd resp data
         | exception Not_found ->
-          let headers = Httpaf.Headers.of_list [ "connection", "close" ] in
-          let resp = Httpaf.Response.create ~headers `Not_found in
-          Httpaf.Reqd.respond_with_string reqd resp "" )
+            let headers = Httpaf.Headers.of_list [ ("connection", "close") ] in
+            let resp = Httpaf.Response.create ~headers `Not_found in
+            Httpaf.Reqd.respond_with_string reqd resp "")
     | _ ->
-      let headers = Httpaf.Headers.of_list [ "connection", "close" ] in
-      let resp = Httpaf.Response.create ~headers `Not_found in
-      Httpaf.Reqd.respond_with_string reqd resp ""
+        let headers = Httpaf.Headers.of_list [ ("connection", "close") ] in
+        let resp = Httpaf.Response.create ~headers `Not_found in
+        Httpaf.Reqd.respond_with_string reqd resp ""
 
-  let provision_certificate ?(production= false) cfg ctx =
+  let provision_certificate ?(production = false) cfg ctx =
     let open Lwt_result.Infix in
     let endpoint =
-      if production then Letsencrypt.letsencrypt_production_url
+      if production
+      then Letsencrypt.letsencrypt_production_url
       else Letsencrypt.letsencrypt_staging_url in
-    Acme.initialise ~ctx ~endpoint ?email:(Option.map Emile.to_string cfg.email)
-      (gen_rsa ?seed:cfg.seed ()) >>= fun le ->
+    Acme.initialise ~ctx ~endpoint
+      ?email:(Option.map Emile.to_string cfg.email)
+      (gen_rsa ?seed:cfg.seed ())
+    >>= fun le ->
     let sleep sec = Time.sleep_ns (Duration.of_sec sec) in
     let priv, csr = csr cfg.certificate_seed cfg.hostname in
     let solver = Letsencrypt.Client.http_solver solver in

--- a/lib/lE.mli
+++ b/lib/lE.mli
@@ -14,4 +14,11 @@ module Make
     configuration ->
     Mimic.ctx ->
     (Tls.Config.own_cert, [> `Msg of string ]) result Lwt.t
+
+  val scheme : [ `HTTP | `HTTPS ] Mimic.value
+  val port : int Mimic.value
+  val domain_name : [ `host ] Domain_name.t Mimic.value
+  val ipaddr : Ipaddr.t Mimic.value
+
+  val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
 end

--- a/lib/lE.mli
+++ b/lib/lE.mli
@@ -1,13 +1,13 @@
-module Make
-    (Time : Mirage_time.S)
-    (Paf : Paf_cohttp.PAF) : sig
-  type configuration =
-    { email : Emile.mailbox option
-    ; seed : string option
-    ; certificate_seed : string option
-    ; hostname : [ `host ] Domain_name.t }
+module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) : sig
+  type configuration = {
+    email : Emile.mailbox option;
+    seed : string option;
+    certificate_seed : string option;
+    hostname : [ `host ] Domain_name.t;
+  }
 
-  val request_handler : (Ipaddr.t * int) -> Httpaf.Server_connection.request_handler
+  val request_handler :
+    Ipaddr.t * int -> Httpaf.Server_connection.request_handler
 
   val provision_certificate :
     ?production:bool ->
@@ -16,8 +16,11 @@ module Make
     (Tls.Config.own_cert, [> `Msg of string ]) result Lwt.t
 
   val scheme : [ `HTTP | `HTTPS ] Mimic.value
+
   val port : int Mimic.value
+
   val domain_name : [ `host ] Domain_name.t Mimic.value
+
   val ipaddr : Ipaddr.t Mimic.value
 
   val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx

--- a/lib/lE.mli
+++ b/lib/lE.mli
@@ -1,0 +1,17 @@
+module Make
+    (Time : Mirage_time.S)
+    (Paf : Paf_cohttp.PAF) : sig
+  type configuration =
+    { email : Emile.mailbox option
+    ; seed : string option
+    ; certificate_seed : string option
+    ; hostname : [ `host ] Domain_name.t }
+
+  val request_handler : (Ipaddr.t * int) -> Httpaf.Server_connection.request_handler
+
+  val provision_certificate :
+    ?production:bool ->
+    configuration ->
+    Mimic.ctx ->
+    (Tls.Config.own_cert, [> `Msg of string ]) result Lwt.t
+end

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -491,11 +491,12 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
          | `Timeout -> Lwt.return_ok `Timeout in
        let stop_result =
          Lwt.pick [ switched_off; loop () ] >>= function
-         | Ok (`Timeout | `Stopped as signal) ->
+         | Ok ((`Timeout | `Stopped) as signal) ->
              let pp_signal ppf = function
                | `Timeout -> Fmt.string ppf "timeout"
                | `Stopped -> Fmt.string ppf "stopped" in
-             Log.debug (fun m -> m "Shutdown the service (%a)." pp_signal signal) ;
+             Log.debug (fun m ->
+                 m "Shutdown the service (%a)." pp_signal signal) ;
              close service >>= fun () -> Lwt.return_ok ()
          | Error _ as err -> close service >>= fun () -> Lwt.return err in
        stop_result >>= function Ok () | Error `Closed -> Lwt.return_unit)

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -19,6 +19,7 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
 
   val http :
     ?config:Httpaf.Config.t ->
+    ?stop:Lwt_switch.t ->
     error_handler:(Ipaddr.t * int -> Httpaf.Server_connection.error_handler) ->
     request_handler:(Ipaddr.t * int -> Httpaf.Server_connection.request_handler) ->
     service ->
@@ -27,6 +28,7 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
   val https :
     tls:Tls.Config.server ->
     ?config:Httpaf.Config.t ->
+    ?stop:Lwt_switch.t ->
     error_handler:(Ipaddr.t * int -> Httpaf.Server_connection.error_handler) ->
     request_handler:(Ipaddr.t * int -> Httpaf.Server_connection.request_handler) ->
     service ->

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -3,19 +3,11 @@
 module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
   exception Error of Mimic.error
 
-  val tcp_edn : (Stack.t * Ipaddr.t * int) Mimic.value
-
-  val tls_edn :
-    ([ `host ] Domain_name.t option
-    * Tls.Config.client
-    * Stack.t
-    * Ipaddr.t
-    * int)
-    Mimic.value
-
   type service
+  (** The type of services. *)
 
   val init : port:int -> Stack.t -> service Lwt.t
+  (** [init ~port stack] returns a {!service} bound on [port] with [stack]. *)
 
   val http :
     ?config:Httpaf.Config.t ->
@@ -24,6 +16,29 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
     request_handler:(Ipaddr.t * int -> Httpaf.Server_connection.request_handler) ->
     service ->
     [ `Initialized of unit Lwt.t ]
+  (** [http ?config ?stop ~error_handler ~request_handler service] promises a
+      service loop computation that is ready to receive connections. The inner
+      promise is then determined once the service loop has ended - by default,
+      only when an error occurs.
+
+      If passed, [stop] is a switch that terminates the service loop, for
+      example to limit execution time to 10 seconds:
+
+      {[
+        let* service = init ~port:80 stack in
+        let stop = Lwt_switch.create () in
+        let `Initialized server = http ~stop ... service in
+        Lwt.both (Lwt_unix.sleep 10. >>= fun () -> Lwt_switch.turn_off stop) server
+      ]}
+
+      This is useful when subsequent actions are reliant on the service loop
+      having begin, such as when testing with a client-server pair:
+
+      {[
+        let* service = init ~port:80 stack in
+        let `Initialized server = http ... service in
+        Lwt.both server (client >|= signal_stop)
+      ]} *)
 
   val https :
     tls:Tls.Config.server ->
@@ -33,6 +48,17 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
     request_handler:(Ipaddr.t * int -> Httpaf.Server_connection.request_handler) ->
     service ->
     [ `Initialized of unit Lwt.t ]
+  (** Same as {!http}, but requires a TLS certificate [tls]. *)
+
+  val tcp_edn : (Stack.t * Ipaddr.t * int) Mimic.value
+
+  val tls_edn :
+    ([ `host ] Domain_name.t option
+    * Tls.Config.client
+    * Stack.t
+    * Ipaddr.t
+    * int)
+    Mimic.value
 
   val request :
     ?config:Httpaf.Config.t ->
@@ -45,4 +71,61 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) : sig
       ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
     Httpaf.Request.t ->
     ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
+  (** [request ?config ~ctx ~error_handler ~response_handler req] returns a
+      {i open} HTTP body according to the given context [ctx] and the request
+      [req].
+
+      To be able to start a simple HTTP connection, you must:
+
+      - know the target IP address
+      - create the client {i stack}
+      - know the target port (default to [80])
+
+      These values must exist into the given [ctx] to, at least, be able to
+      start a TCP/IP connection:
+
+      {[
+        let ctx =
+          Mimic.add Paf.tcp_edn
+            (stack, ipaddr_of_google, 80)
+            Mimic.empty Paf.request ~ctx ~error_handler ~response_handler req
+      ]}
+
+      The user is able to fill the [ctx] with some clever processes such as a
+      DNS resolver:
+
+      {[
+        let domain_name = Mimic.make ~name:"domain-name"
+
+        let ipaddr = Mimic.make ~name:"ipaddr"
+
+        let resolver domain_name =
+          match Unix.gethostbyname (Domain_name.to_string domain_name) with
+          | { Unix.h_addr_list; _ } ->
+              if Array.length h_addr_list > 0
+              then Lwt.return_some (Ipaddr_unix.of_inet_addr h_addr_list.(0))
+              else Lwt.return_none
+          | exception _ -> Lwt.return_none
+
+        let stack = Mimic.make ~name:"stack"
+
+        let port = Mimic.make ~name:"port"
+
+        let connect stack ipaddr port = Lwt.return_some (stack, ipaddr, port)
+
+        let ctx =
+          let open Mimic in
+          fold ipaddr Fun.[ req domain_name ] ~k:resolver Mimic.empty
+          |> fold Paf.tcp_edn
+               Fun.[ req stack; req ipaddr; dft port 80 ]
+               ~k:connect
+      ]}
+
+      If [mimic] is able to create a {!tcp_edn} value from the [ctx] and these
+      functions, the user will be able to start a TCP/IP connection. [ipaddr]
+      will come from a given [domain_name] and if the [port] is missing, we use
+      [80] as the default value. The [stack] still is required.
+
+      For a more user-friendly interface, you should take a look into
+      [paf.cohttp]. *)
 end

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -83,6 +83,7 @@ module Make (Paf : PAF) = struct
     ctx
 
   let call ?(ctx= default_ctx) ?headers ?body:(cohttp_body= Cohttp_lwt.Body.empty) ?chunked:_ meth uri =
+    let ctx = with_uri uri ctx in
     let config = match Mimic.get httpaf_config ctx with
       | Some config -> config | None -> Httpaf.Config.default in
     let headers = match headers with

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -1,0 +1,115 @@
+module type PAF = sig
+  val request :
+    ?config:Httpaf.Config.t ->
+    ctx:Mimic.ctx ->
+    error_handler:
+      (Mimic.flow ->
+       (Ipaddr.t * int) option ->
+       Httpaf.Client_connection.error_handler) ->
+    response_handler:
+      ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
+    Httpaf.Request.t ->
+    ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
+end
+
+module Make (Paf : PAF) = struct
+  open Paf
+
+  type ctx = Mimic.ctx
+
+  let sexp_of_ctx _ctx = assert false
+  let default_ctx = Mimic.empty
+
+  let httpaf_config = Mimic.make ~name:"httpaf-config"
+
+  let error_handler mvar flow edn err =
+    Lwt.async @@ fun () -> Lwt_mvar.put mvar (flow, edn, err)
+
+  let response_handler mvar pusher _edn resp body =
+    let on_eof () = pusher None in
+    let rec on_read buf ~off ~len =
+      let str = Bigstringaf.substring buf ~off ~len in
+      pusher (Some str) ;
+      Httpaf.Body.schedule_read ~on_eof ~on_read body in
+    Httpaf.Body.schedule_read ~on_eof ~on_read body ;
+    Lwt.async @@ fun () -> Lwt_mvar.put mvar resp
+
+  let rec unroll body stream =
+    let open Lwt.Infix in
+    Lwt_stream.get stream >>= function
+    | Some str -> Httpaf.Body.write_string body str ; unroll body stream
+    | None -> Httpaf.Body.close_writer body ; Lwt.return_unit
+
+  let transmit cohttp_body httpaf_body = match cohttp_body with
+    | `Empty -> Httpaf.Body.close_writer httpaf_body
+    | `String str ->
+      Httpaf.Body.write_string httpaf_body str ;
+      Httpaf.Body.close_writer httpaf_body
+    | `Strings sstr ->
+      List.iter (Httpaf.Body.write_string httpaf_body) sstr ;
+      Httpaf.Body.close_writer httpaf_body
+    | `Stream stream -> Lwt.async @@ fun () -> unroll httpaf_body stream
+
+  exception Internal_server_error
+  exception Invalid_response_body_length of Httpaf.Response.t
+  exception Malformed_response of string
+
+  let call ?(ctx= default_ctx) ?headers ?body:(cohttp_body= Cohttp_lwt.Body.empty) ?chunked:_ meth uri =
+    let config = match Mimic.get httpaf_config ctx with
+      | Some config -> config | None -> Httpaf.Config.default in
+    let headers = match headers with
+      | Some headers -> Httpaf.Headers.of_list (Cohttp.Header.to_list headers)
+      | None -> Httpaf.Headers.empty in
+    let meth = match meth with
+      | #Httpaf.Method.t as meth -> meth
+      | #Cohttp.Code.meth as meth -> `Other (Cohttp.Code.string_of_method meth) in
+    let req = Httpaf.Request.create ~headers meth (Uri.path uri) in
+    let stream, pusher = Lwt_stream.create () in
+    let mvar_res = Lwt_mvar.create_empty () in
+    let mvar_err = Lwt_mvar.create_empty () in
+    let open Lwt.Infix in
+    request ~config ~ctx ~error_handler:(error_handler mvar_err) ~response_handler:(response_handler mvar_res pusher) req >>= function
+    | Error (#Mimic.error as err) -> Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
+    | Ok httpaf_body ->
+      transmit cohttp_body httpaf_body ;
+      Lwt.pick
+        [ Lwt_mvar.take mvar_res >|= (fun res -> `Response res)
+        ; Lwt_mvar.take mvar_err >|= (fun err -> `Error err) ] >>= function
+      | `Error (flow, _, `Exn exn) ->
+        Mimic.close flow >>= fun () -> Lwt.fail exn
+      | `Error (flow, _, `Invalid_response_body_length resp) ->
+        Mimic.close flow >>= fun () ->
+        Lwt.fail (Invalid_response_body_length resp)
+      | `Error (flow, _, `Malformed_response err) ->
+        Mimic.close flow >>= fun () ->
+        Lwt.fail (Malformed_response err)
+      | `Response resp ->
+        let version = match resp.Httpaf.Response.version with
+          | { Httpaf.Version.major= 1; minor= 0; } -> `HTTP_1_0
+          | { major= 1; minor= 1; } -> `HTTP_1_1
+          | { major; minor; } -> `Other (Fmt.str "%d.%d" major minor) in
+        let status = match (resp.Httpaf.Response.status :> [ Cohttp.Code.status | Httpaf.Status.t ]) with
+          | #Cohttp.Code.status as status -> status
+          | #Httpaf.Status.t as status -> `Code (Httpaf.Status.to_code status) in
+        let encoding = match meth with
+          | #Httpaf.Method.standard as meth ->
+            ( match Httpaf.Response.body_length ~request_method:meth resp with
+              | `Chunked | `Close_delimited -> Cohttp.Transfer.Chunked
+              | `Error _err -> raise Internal_server_error
+              | `Fixed length -> Cohttp.Transfer.Fixed length )
+          | _ -> Cohttp.Transfer.Chunked in
+        let headers = Cohttp.Header.of_list (Httpaf.Headers.to_list resp.Httpaf.Response.headers) in
+        let resp = Cohttp.Response.make ~version ~status ~encoding ~headers () in
+        Lwt.return (resp, `Stream stream)
+
+  open Lwt.Infix
+
+  let head ?ctx ?headers uri = call ?ctx ?headers `HEAD uri >|= fst
+  let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
+  let delete ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `DELETE uri
+  let post ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `POST uri
+  let put ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `PUT uri
+  let patch ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `PATCH uri
+  let post_form ?ctx:_ ?headers:_ ~params:_ _uri = assert false (* TODO *)
+  let callv ?ctx:_ _uri _stream = assert false (* TODO *)
+end

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -173,6 +173,7 @@ module Make (Paf : PAF) = struct
         Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
     | Ok httpaf_body -> (
         transmit cohttp_body httpaf_body ;
+        Log.debug (fun m -> m "Body transmitted.") ;
         Lwt.pick
           [
             (Lwt_mvar.take mvar_res >|= fun res -> `Response res);
@@ -187,6 +188,7 @@ module Make (Paf : PAF) = struct
         | `Error (flow, _, `Malformed_response err) ->
             Mimic.close flow >>= fun () -> Lwt.fail (Malformed_response err)
         | `Response resp ->
+            Log.debug (fun m -> m "Response received.") ;
             let version =
               match resp.Httpaf.Response.version with
               | { Httpaf.Version.major = 1; minor = 0 } -> `HTTP_1_0

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -4,8 +4,8 @@ module type PAF = sig
     ctx:Mimic.ctx ->
     error_handler:
       (Mimic.flow ->
-       (Ipaddr.t * int) option ->
-       Httpaf.Client_connection.error_handler) ->
+      (Ipaddr.t * int) option ->
+      Httpaf.Client_connection.error_handler) ->
     response_handler:
       ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
     Httpaf.Request.t ->
@@ -15,9 +15,14 @@ end
 module Make (Paf : PAF) = struct
   open Paf
 
+  let src = Logs.Src.create "paf-cohttp"
+
+  module Log = (val Logs.src_log src : Logs.LOG)
+
   type ctx = Mimic.ctx
 
   let sexp_of_ctx _ctx = assert false
+
   let default_ctx = Mimic.empty
 
   let httpaf_config = Mimic.make ~name:"httpaf-config"
@@ -37,108 +42,185 @@ module Make (Paf : PAF) = struct
   let rec unroll body stream =
     let open Lwt.Infix in
     Lwt_stream.get stream >>= function
-    | Some str -> Httpaf.Body.write_string body str ; unroll body stream
-    | None -> Httpaf.Body.close_writer body ; Lwt.return_unit
+    | Some str ->
+        Log.debug (fun m -> m "Transmit to HTTP/AF: %S." str) ;
+        Httpaf.Body.write_string body str ;
+        unroll body stream
+    | None ->
+        Log.debug (fun m -> m "Close the HTTP/AF writer.") ;
+        Httpaf.Body.close_writer body ;
+        Lwt.return_unit
 
-  let transmit cohttp_body httpaf_body = match cohttp_body with
+  let transmit cohttp_body httpaf_body =
+    match cohttp_body with
     | `Empty -> Httpaf.Body.close_writer httpaf_body
     | `String str ->
-      Httpaf.Body.write_string httpaf_body str ;
-      Httpaf.Body.close_writer httpaf_body
+        Httpaf.Body.write_string httpaf_body str ;
+        Httpaf.Body.close_writer httpaf_body
     | `Strings sstr ->
-      List.iter (Httpaf.Body.write_string httpaf_body) sstr ;
-      Httpaf.Body.close_writer httpaf_body
+        List.iter (Httpaf.Body.write_string httpaf_body) sstr ;
+        Httpaf.Body.close_writer httpaf_body
     | `Stream stream -> Lwt.async @@ fun () -> unroll httpaf_body stream
 
   exception Internal_server_error
+
   exception Invalid_response_body_length of Httpaf.Response.t
+
   exception Malformed_response of string
 
   let scheme = Mimic.make ~name:"scheme"
+
   let port = Mimic.make ~name:"port"
+
   let domain_name = Mimic.make ~name:"domain-name"
+
   let ipaddr = Mimic.make ~name:"ipaddr"
 
   let with_uri uri ctx =
-    let scheme_v = match Uri.scheme uri with
+    let scheme_v =
+      match Uri.scheme uri with
       | Some "http" -> Some `HTTP
       | Some "https" -> Some `HTTPS
       | _ -> None in
-    let port_v = match Uri.port uri, scheme_v with
+    let port_v =
+      match (Uri.port uri, scheme_v) with
       | Some port, _ -> Some port
       | None, Some `HTTP -> Some 80
       | None, Some `HTTPS -> Some 443
       | _ -> None in
-    let domain_name_v, ipaddr_v = match Uri.host uri with
-      | Some v ->
-        ( match Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v with
-        | _, Ok v -> None, Some v
-        | Ok v, _ -> Some v, None
-        | _ -> None, None )
-      | _ -> None, None in
-    let ctx = Option.fold ~none:ctx ~some:(fun v -> Mimic.add scheme v ctx) scheme_v in
-    let ctx = Option.fold ~none:ctx ~some:(fun v -> Mimic.add port v ctx) port_v in
-    let ctx = Option.fold ~none:ctx ~some:(fun v -> Mimic.add ipaddr v ctx) ipaddr_v in
-    let ctx = Option.fold ~none:ctx ~some:(fun v -> Mimic.add domain_name v ctx) domain_name_v in
+    let domain_name_v, ipaddr_v =
+      match Uri.host uri with
+      | Some v -> (
+          match
+            (Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v)
+          with
+          | _, Ok v -> (None, Some v)
+          | Ok v, _ -> (Some v, None)
+          | _ -> (None, None))
+      | _ -> (None, None) in
+    let ctx =
+      Option.fold ~none:ctx ~some:(fun v -> Mimic.add scheme v ctx) scheme_v
+    in
+    let ctx =
+      Option.fold ~none:ctx ~some:(fun v -> Mimic.add port v ctx) port_v in
+    let ctx =
+      Option.fold ~none:ctx ~some:(fun v -> Mimic.add ipaddr v ctx) ipaddr_v
+    in
+    let ctx =
+      Option.fold ~none:ctx
+        ~some:(fun v -> Mimic.add domain_name v ctx)
+        domain_name_v in
     ctx
 
-  let call ?(ctx= default_ctx) ?headers ?body:(cohttp_body= Cohttp_lwt.Body.empty) ?chunked:_ meth uri =
+  let with_host headers uri =
+    let hostname = Uri.host_with_default ~default:"localhost" uri in
+    let hostname =
+      match Uri.port uri with
+      | Some port -> Fmt.str "%s:%d" hostname port
+      | None -> hostname in
+    Httpaf.Headers.add_unless_exists headers "host" hostname
+
+  let with_transfer_encoding headers =
+    match Httpaf.Headers.get headers "content-length" with
+    | Some _ -> headers
+    | None ->
+        Httpaf.Headers.add_unless_exists headers "transfer-encoding" "chunked"
+
+  let call ?(ctx = default_ctx) ?headers
+      ?body:(cohttp_body = Cohttp_lwt.Body.empty) ?chunked:_ meth uri =
+    Log.debug (fun m -> m "Fill the context with %a." Uri.pp uri) ;
     let ctx = with_uri uri ctx in
-    let config = match Mimic.get httpaf_config ctx with
-      | Some config -> config | None -> Httpaf.Config.default in
-    let headers = match headers with
+    let config =
+      match Mimic.get httpaf_config ctx with
+      | Some config -> config
+      | None -> Httpaf.Config.default in
+    let headers =
+      match headers with
       | Some headers -> Httpaf.Headers.of_list (Cohttp.Header.to_list headers)
       | None -> Httpaf.Headers.empty in
-    let meth = match meth with
+    let headers = with_host headers uri in
+    let headers = with_transfer_encoding headers in
+    let meth =
+      match meth with
       | #Httpaf.Method.t as meth -> meth
-      | #Cohttp.Code.meth as meth -> `Other (Cohttp.Code.string_of_method meth) in
+      | #Cohttp.Code.meth as meth -> `Other (Cohttp.Code.string_of_method meth)
+    in
     let req = Httpaf.Request.create ~headers meth (Uri.path uri) in
     let stream, pusher = Lwt_stream.create () in
     let mvar_res = Lwt_mvar.create_empty () in
     let mvar_err = Lwt_mvar.create_empty () in
     let open Lwt.Infix in
-    request ~config ~ctx ~error_handler:(error_handler mvar_err) ~response_handler:(response_handler mvar_res pusher) req >>= function
-    | Error (#Mimic.error as err) -> Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
-    | Ok httpaf_body ->
-      transmit cohttp_body httpaf_body ;
-      Lwt.pick
-        [ Lwt_mvar.take mvar_res >|= (fun res -> `Response res)
-        ; Lwt_mvar.take mvar_err >|= (fun err -> `Error err) ] >>= function
-      | `Error (flow, _, `Exn exn) ->
-        Mimic.close flow >>= fun () -> Lwt.fail exn
-      | `Error (flow, _, `Invalid_response_body_length resp) ->
-        Mimic.close flow >>= fun () ->
-        Lwt.fail (Invalid_response_body_length resp)
-      | `Error (flow, _, `Malformed_response err) ->
-        Mimic.close flow >>= fun () ->
-        Lwt.fail (Malformed_response err)
-      | `Response resp ->
-        let version = match resp.Httpaf.Response.version with
-          | { Httpaf.Version.major= 1; minor= 0; } -> `HTTP_1_0
-          | { major= 1; minor= 1; } -> `HTTP_1_1
-          | { major; minor; } -> `Other (Fmt.str "%d.%d" major minor) in
-        let status = match (resp.Httpaf.Response.status :> [ Cohttp.Code.status | Httpaf.Status.t ]) with
-          | #Cohttp.Code.status as status -> status
-          | #Httpaf.Status.t as status -> `Code (Httpaf.Status.to_code status) in
-        let encoding = match meth with
-          | #Httpaf.Method.standard as meth ->
-            ( match Httpaf.Response.body_length ~request_method:meth resp with
-              | `Chunked | `Close_delimited -> Cohttp.Transfer.Chunked
-              | `Error _err -> raise Internal_server_error
-              | `Fixed length -> Cohttp.Transfer.Fixed length )
-          | _ -> Cohttp.Transfer.Chunked in
-        let headers = Cohttp.Header.of_list (Httpaf.Headers.to_list resp.Httpaf.Response.headers) in
-        let resp = Cohttp.Response.make ~version ~status ~encoding ~headers () in
-        Lwt.return (resp, `Stream stream)
+    request ~config ~ctx ~error_handler:(error_handler mvar_err)
+      ~response_handler:(response_handler mvar_res pusher)
+      req
+    >>= function
+    | Error (#Mimic.error as err) ->
+        Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
+    | Ok httpaf_body -> (
+        transmit cohttp_body httpaf_body ;
+        Lwt.pick
+          [
+            (Lwt_mvar.take mvar_res >|= fun res -> `Response res);
+            (Lwt_mvar.take mvar_err >|= fun err -> `Error err);
+          ]
+        >>= function
+        | `Error (flow, _, `Exn exn) ->
+            Mimic.close flow >>= fun () -> Lwt.fail exn
+        | `Error (flow, _, `Invalid_response_body_length resp) ->
+            Mimic.close flow >>= fun () ->
+            Lwt.fail (Invalid_response_body_length resp)
+        | `Error (flow, _, `Malformed_response err) ->
+            Mimic.close flow >>= fun () -> Lwt.fail (Malformed_response err)
+        | `Response resp ->
+            let version =
+              match resp.Httpaf.Response.version with
+              | { Httpaf.Version.major = 1; minor = 0 } -> `HTTP_1_0
+              | { major = 1; minor = 1 } -> `HTTP_1_1
+              | { major; minor } -> `Other (Fmt.str "%d.%d" major minor) in
+            let status =
+              match
+                (resp.Httpaf.Response.status
+                  :> [ Cohttp.Code.status | Httpaf.Status.t ])
+              with
+              | #Cohttp.Code.status as status -> status
+              | #Httpaf.Status.t as status ->
+                  `Code (Httpaf.Status.to_code status) in
+            let encoding =
+              match meth with
+              | #Httpaf.Method.standard as meth -> (
+                  match
+                    Httpaf.Response.body_length ~request_method:meth resp
+                  with
+                  | `Chunked | `Close_delimited -> Cohttp.Transfer.Chunked
+                  | `Error _err -> raise Internal_server_error
+                  | `Fixed length -> Cohttp.Transfer.Fixed length)
+              | _ -> Cohttp.Transfer.Chunked in
+            let headers =
+              Cohttp.Header.of_list
+                (Httpaf.Headers.to_list resp.Httpaf.Response.headers) in
+            let resp =
+              Cohttp.Response.make ~version ~status ~encoding ~headers () in
+            Lwt.return (resp, `Stream stream))
 
   open Lwt.Infix
 
   let head ?ctx ?headers uri = call ?ctx ?headers `HEAD uri >|= fst
+
   let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
-  let delete ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `DELETE uri
-  let post ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `POST uri
-  let put ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `PUT uri
-  let patch ?ctx ?body ?chunked ?headers uri = call ?ctx ?body ?chunked ?headers `PATCH uri
+
+  let delete ?ctx ?body ?chunked ?headers uri =
+    call ?ctx ?body ?chunked ?headers `DELETE uri
+
+  let post ?ctx ?body ?chunked ?headers uri =
+    call ?ctx ?body ?chunked ?headers `POST uri
+
+  let put ?ctx ?body ?chunked ?headers uri =
+    call ?ctx ?body ?chunked ?headers `PUT uri
+
+  let patch ?ctx ?body ?chunked ?headers uri =
+    call ?ctx ?body ?chunked ?headers `PATCH uri
+
   let post_form ?ctx:_ ?headers:_ ~params:_ _uri = assert false (* TODO *)
+
   let callv ?ctx:_ _uri _stream = assert false (* TODO *)
 end

--- a/lib/paf_cohttp.mli
+++ b/lib/paf_cohttp.mli
@@ -1,0 +1,16 @@
+module type PAF = sig
+  val request :
+    ?config:Httpaf.Config.t ->
+    ctx:Mimic.ctx ->
+    error_handler:
+      (Mimic.flow ->
+       (Ipaddr.t * int) option ->
+       Httpaf.Client_connection.error_handler) ->
+    response_handler:
+      ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
+    Httpaf.Request.t ->
+    ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
+end
+
+module Make (Paf : PAF) : Cohttp_lwt.S.Client
+  with type ctx = Mimic.ctx

--- a/lib/paf_cohttp.mli
+++ b/lib/paf_cohttp.mli
@@ -4,8 +4,8 @@ module type PAF = sig
     ctx:Mimic.ctx ->
     error_handler:
       (Mimic.flow ->
-       (Ipaddr.t * int) option ->
-       Httpaf.Client_connection.error_handler) ->
+      (Ipaddr.t * int) option ->
+      Httpaf.Client_connection.error_handler) ->
     response_handler:
       ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
     Httpaf.Request.t ->
@@ -13,12 +13,14 @@ module type PAF = sig
 end
 
 module Make (Paf : PAF) : sig
-  include Cohttp_lwt.S.Client
-    with type ctx = Mimic.ctx
+  include Cohttp_lwt.S.Client with type ctx = Mimic.ctx
 
   val scheme : [ `HTTP | `HTTPS ] Mimic.value
+
   val port : int Mimic.value
+
   val domain_name : [ `host ] Domain_name.t Mimic.value
+
   val ipaddr : Ipaddr.t Mimic.value
 
   val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx

--- a/lib/paf_cohttp.mli
+++ b/lib/paf_cohttp.mli
@@ -12,5 +12,14 @@ module type PAF = sig
     ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
 end
 
-module Make (Paf : PAF) : Cohttp_lwt.S.Client
-  with type ctx = Mimic.ctx
+module Make (Paf : PAF) : sig
+  include Cohttp_lwt.S.Client
+    with type ctx = Mimic.ctx
+
+  val scheme : [ `HTTP | `HTTPS ] Mimic.value
+  val port : int Mimic.value
+  val domain_name : [ `host ] Domain_name.t Mimic.value
+  val ipaddr : Ipaddr.t Mimic.value
+
+  val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
+end

--- a/paf.opam
+++ b/paf.opam
@@ -34,7 +34,3 @@ depends: [
   "ptime"             {with-test}
   "uri"               {with-test}
 ]
-
-pin-depends: [
-  [ "mimic.dev" "git+https://github.com/mirage/ocaml-git.git#9c757989170ccf94dd74e920e6290ea85d38aca5" ]
-]

--- a/paf.opam
+++ b/paf.opam
@@ -33,4 +33,5 @@ depends: [
   "mirage-time-unix"  {with-test}
   "ptime"             {with-test}
   "uri"               {with-test}
+  "alcotest-lwt"      {with-test}
 ]

--- a/paf.opam
+++ b/paf.opam
@@ -20,6 +20,9 @@ depends: [
   "httpaf"
   "tls-mirage"
   "mimic"
+  "cohttp-lwt"
+  "letsencrypt"
+  "emile"
   "ke"                {>= "0.4"}
   "lwt"               {with-test}
   "base-unix"         {with-test}

--- a/test/clients.ml
+++ b/test/clients.ml
@@ -30,10 +30,10 @@ let run uri =
 let run_client uri =
   run_process (fun () ->
       let () = Mirage_crypto_rng_unix.initialize () in
-      let () =
-        Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true () in
-      let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr) in
-      let () = Logs.set_level ~all:true (Some Logs.Debug) in
+      (* let () =
+           Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true () in
+         let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr) in
+         let () = Logs.set_level ~all:true (Some Logs.Debug) in *)
       Lwt_main.run (run uri))
 
 let const x _ = x

--- a/test/clients.ml
+++ b/test/clients.ml
@@ -20,12 +20,6 @@ let reporter pid ppf =
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
   { Logs.report }
 
-let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
-
-let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr)
-
-let () = Logs.set_level ~all:true (Some Logs.Debug)
-
 let run uri =
   let open Lwt.Infix in
   let t0 = now () in
@@ -36,7 +30,6 @@ let run uri =
 let run_client uri =
   run_process (fun () ->
       let () = Mirage_crypto_rng_unix.initialize () in
-      let () = Logs.set_reporter Logs.nop_reporter in
       Lwt_main.run (run uri))
 
 let const x _ = x

--- a/test/clients.ml
+++ b/test/clients.ml
@@ -20,6 +20,12 @@ let reporter pid ppf =
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
   { Logs.report }
 
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+
+let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr)
+
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+
 let run uri =
   let open Lwt.Infix in
   let t0 = now () in
@@ -30,10 +36,7 @@ let run uri =
 let run_client uri =
   run_process (fun () ->
       let () = Mirage_crypto_rng_unix.initialize () in
-      (* let () =
-           Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true () in
-         let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr) in
-         let () = Logs.set_level ~all:true (Some Logs.Debug) in *)
+      let () = Logs.set_reporter Logs.nop_reporter in
       Lwt_main.run (run uri))
 
 let const x _ = x

--- a/test/clients.ml
+++ b/test/clients.ml
@@ -30,9 +30,10 @@ let run uri =
 let run_client uri =
   run_process (fun () ->
       let () = Mirage_crypto_rng_unix.initialize () in
-      (* let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true () in
-         let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr) in
-         let () = Logs.set_level ~all:true (Some Logs.Debug) in *)
+      let () =
+        Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true () in
+      let () = Logs.set_reporter (reporter (Unix.getpid ()) Fmt.stderr) in
+      let () = Logs.set_level ~all:true (Some Logs.Debug) in
       Lwt_main.run (run uri))
 
 let const x _ = x
@@ -170,7 +171,7 @@ let () =
   match !uri with
   | Some uri ->
       Fiber.set_concurrency !concurrency ;
-      Lwt_preemptive.init !concurrency !concurrency ignore ;
+      (* Lwt_preemptive.init !concurrency !concurrency ignore ; *)
       let res = Fiber.run (clients ~n:!number uri) in
       show res
   | None ->

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (library
  (name fiber)
  (modules fiber)
- (libraries lwt.unix unix))
+ (libraries fmt lwt.unix unix))
 
 (executable
  (name simple_server)

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (library
  (name fiber)
  (modules fiber)
- (libraries fmt lwt.unix unix))
+ (libraries fmt logs lwt.unix unix))
 
 (executable
  (name simple_server)

--- a/test/dune
+++ b/test/dune
@@ -28,9 +28,21 @@
  (modules test)
  (libraries uri unix))
 
+(executable
+ (name test_cohttp)
+ (modules test_cohttp)
+ (libraries fmt.tty logs.fmt alcotest-lwt mirage-time-unix tcpip.stack-socket
+   cohttp-lwt paf.cohttp mirage-crypto-rng.unix))
+
 (rule
  (alias runtest)
  (deps server.pem server.key file.txt %{exe:clients.exe}
    %{exe:simple_server.exe})
  (action
   (run ./test.exe -c 50 -n 200)))
+
+(rule
+ (alias runtest)
+ (deps server.pem server.key %{exe:test_cohttp.exe})
+ (action
+  (run ./test_cohttp.exe --color=always)))

--- a/test/dune
+++ b/test/dune
@@ -36,6 +36,7 @@
 
 (rule
  (alias runtest)
+ (locks m)
  (deps server.pem server.key file.txt %{exe:clients.exe}
    %{exe:simple_server.exe})
  (action
@@ -43,6 +44,7 @@
 
 (rule
  (alias runtest)
+ (locks m)
  (deps server.pem server.key %{exe:test_cohttp.exe})
  (action
   (run ./test_cohttp.exe --color=always)))

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -67,7 +67,8 @@ let scheme = Mimic.make ~name:"scheme"
 
 let tls = Mimic.make ~name:"tls"
 
-let tcp_connect scheme stack ipaddr port = match scheme with
+let tcp_connect scheme stack ipaddr port =
+  match scheme with
   | `HTTPS -> Lwt.return_some (stack, ipaddr, port)
   | `HTTP -> Lwt.return_none
 
@@ -79,7 +80,8 @@ let dns_resolve domain_name =
       else Lwt.return_none
   | exception _ -> Lwt.return_none
 
-let tls_connect scheme domain_name cfg stack ipaddr port = match scheme with
+let tls_connect scheme domain_name cfg stack ipaddr port =
+  match scheme with
   | `HTTPS -> Lwt.return_some (domain_name, cfg, stack, ipaddr, port)
   | `HTTP -> Lwt.return_none
 
@@ -91,7 +93,15 @@ let ctx =
          ~k:tcp_connect)
   |> Mimic.(
        fold Paf.tls_edn
-         Fun.[ req scheme; opt domain_name; dft tls null; req stack; req ipaddr; dft port 443; ]
+         Fun.
+           [
+             req scheme;
+             opt domain_name;
+             dft tls null;
+             req stack;
+             req ipaddr;
+             dft port 443;
+           ]
          ~k:tls_connect)
   |> Mimic.(fold ipaddr Fun.[ req domain_name ] ~k:dns_resolve)
 
@@ -105,7 +115,8 @@ let run uri =
           [ `Body of string | `Done | Httpaf.Client_connection.error ] Lwt.u) )
       =
     Lwt.wait () in
-  let ctx = match Uri.scheme uri with
+  let ctx =
+    match Uri.scheme uri with
     | Some "http" -> Mimic.add scheme `HTTP ctx
     | Some "https" -> Mimic.add scheme `HTTPS ctx
     | _ -> ctx in

--- a/test/test.ml
+++ b/test/test.ml
@@ -98,6 +98,9 @@ let () =
   let lock0, lock1, pid0, pid1 = launch_server () in
   lock lock0 ;
   lock lock1 ;
+  Unix.sleep 2 ;
+  (* XXX(dinosaure): needed because [Paf.init/Stack.listen] does not ensure that
+   * we listen **after**. Lwt can schedule it in an other way... see mirage/mirage-tcpip#438 *)
   launch_clients !concurrency !number (Uri.of_string "https://localhost:4343/") ;
   launch_clients !concurrency !number
     (Uri.of_string "https://localhost:4343/large") ;

--- a/test/test_cohttp.ml
+++ b/test/test_cohttp.ml
@@ -1,0 +1,221 @@
+open Lwt.Infix
+
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over () ;
+      k () in
+    let with_metadata header _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("%a[%a]: " ^^ fmt ^^ "\n%!")
+        Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
+    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
+  { Logs.report }
+
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+
+let () = Logs.set_reporter (reporter Fmt.stderr)
+
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+
+let () = Mirage_crypto_rng_unix.initialize ()
+
+module Paf = Paf.Make (Time) (Tcpip_stack_socket.V4V6)
+
+let unix_stack () =
+  Tcpip_stack_socket.V4V6.UDP.connect ~ipv4_only:false ~ipv6_only:false
+    Ipaddr.V4.Prefix.global None
+  >>= fun udpv4 ->
+  Tcpip_stack_socket.V4V6.TCP.connect ~ipv4_only:false ~ipv6_only:false
+    Ipaddr.V4.Prefix.global None
+  >>= fun tcpv4 -> Tcpip_stack_socket.V4V6.connect udpv4 tcpv4
+
+let error_handler (_ip, _port) ?request:_ _error _respond = ()
+
+let load_file filename =
+  let ic = open_in filename in
+  let ln = in_channel_length ic in
+  let rs = Bytes.create ln in
+  really_input ic rs 0 ln ;
+  close_in ic ;
+  Cstruct.of_bytes rs
+
+let tls =
+  let cert = load_file "server.pem" in
+  let key = load_file "server.key" in
+  match
+    (X509.Certificate.decode_pem_multiple cert, X509.Private_key.decode_pem key)
+  with
+  | Ok certs, Ok (`RSA key) ->
+      Tls.Config.server ~certificates:(`Single (certs, key)) ()
+  | _ -> invalid_arg "Invalid certificate or key"
+
+let run_http_and_https_server ~request_handler stop =
+  unix_stack () >>= fun stack ->
+  Paf.init ~port:8080 stack >>= fun http ->
+  Paf.init ~port:4343 stack >>= fun https ->
+  let (`Initialized fiber0) =
+    Paf.http ~stop ~error_handler ~request_handler http in
+  let (`Initialized fiber1) =
+    Paf.https ~tls ~stop ~error_handler ~request_handler https in
+  Logs.debug (fun m -> m "Server initialised.") ;
+  Lwt.async (fun () -> Lwt.join [ fiber0; fiber1 ]) ;
+  Lwt.return_unit
+
+let resolver domain_name =
+  match Unix.gethostbyname (Domain_name.to_string domain_name) with
+  | { Unix.h_addr_list; _ } ->
+      if Array.length h_addr_list > 0
+      then Lwt.return_some (Ipaddr_unix.of_inet_addr h_addr_list.(0))
+      else Lwt.return_none
+  | exception _ -> Lwt.return_none
+
+let tcp_connect scheme stack ipaddr port =
+  match scheme with
+  | `HTTP -> Lwt.return_some (stack, ipaddr, port)
+  | _ -> Lwt.return_none
+
+let tls_connect scheme domain_name cfg stack ipaddr port =
+  match scheme with
+  | `HTTPS -> Lwt.return_some (domain_name, cfg, stack, ipaddr, port)
+  | _ -> Lwt.return_none
+
+let null =
+  let authenticator ~host:_ _ = Ok None in
+  Tls.Config.client ~authenticator ()
+
+module Client = Paf_cohttp.Make (Paf)
+
+let stack = Mimic.make ~name:"stack"
+
+let ctx =
+  let tls = Mimic.make ~name:"tls" in
+  Mimic.empty
+  |> Mimic.(
+       fold Paf.tcp_edn
+         Fun.
+           [
+             req Client.scheme;
+             req stack;
+             req Client.ipaddr;
+             dft Client.port 8080;
+           ]
+         ~k:tcp_connect)
+  |> Mimic.(
+       fold Paf.tls_edn
+         Fun.
+           [
+             req Client.scheme;
+             opt Client.domain_name;
+             dft tls null;
+             req stack;
+             req Client.ipaddr;
+             dft Client.port 4343;
+           ]
+         ~k:tls_connect)
+  |> Mimic.(fold Client.ipaddr Fun.[ req Client.domain_name ] ~k:resolver)
+
+let body_to_string body =
+  let buf = Buffer.create 0x100 in
+  let th, wk = Lwt.wait () in
+  let on_eof () =
+    Lwt.wakeup_later wk (Buffer.contents buf) ;
+    Httpaf.Body.close_reader body in
+  let rec on_read str ~off ~len =
+    let str = Bigstringaf.substring str ~off ~len in
+    Logs.debug (fun m -> m "Received %S." str) ;
+    Buffer.add_string buf str ;
+    Httpaf.Body.schedule_read body ~on_eof ~on_read in
+  Logs.debug (fun m -> m "Start to receive the body.") ;
+  Httpaf.Body.schedule_read body ~on_eof ~on_read ;
+  th
+
+let request_handler (ip, port) reqd =
+  let open Httpaf in
+  let req = Reqd.request reqd in
+  Logs.debug (fun m ->
+      m "Got a connection from %a:%d %s." Ipaddr.pp ip port req.Request.target) ;
+  let body = Reqd.request_body reqd in
+  match req.Request.target with
+  | "/" ->
+      let contents = "Hello World!" in
+      let headers =
+        Headers.of_list
+          [ ("content-length", string_of_int (String.length contents)) ] in
+      let resp = Response.create ~headers `OK in
+      Reqd.respond_with_string reqd resp contents ;
+      Lwt.async @@ fun () ->
+      body_to_string body >>= fun _ ->
+      Logs.debug (fun m -> m "Body drained.") ;
+      Lwt.return_unit
+  | "/repeat" ->
+      Lwt.async @@ fun () ->
+      body_to_string body >>= fun str ->
+      let headers =
+        Headers.of_list
+          [ ("content-length", string_of_int (String.length str)) ] in
+      let resp = Response.create ~headers `OK in
+      Reqd.respond_with_string reqd resp str ;
+      Lwt.return_unit
+  | _ ->
+      Reqd.report_exn reqd Not_found ;
+      let contents = "Invalid request." in
+      let headers =
+        Headers.of_list
+          [ ("content-length", string_of_int (String.length contents)) ] in
+      let resp = Response.create ~headers `Bad_request in
+      Reqd.respond_with_string reqd resp contents
+
+let test01 =
+  Alcotest_lwt.test_case "simple-http" `Quick @@ fun _sw () ->
+  unix_stack () >>= fun v ->
+  let ctx = Mimic.add stack v ctx in
+  Client.get ~ctx (Uri.of_string "http://localhost:8080/")
+  >>= fun (_resp, body) ->
+  Cohttp_lwt.Body.to_string body >>= fun str ->
+  Alcotest.(check string) "contents" str "Hello World!" ;
+  Lwt.return_unit
+
+let test02 =
+  Alcotest_lwt.test_case "repeat" `Quick @@ fun _sw () ->
+  unix_stack () >>= fun v ->
+  let ctx = Mimic.add stack v ctx in
+  let body = Cohttp_lwt.Body.of_string "Hello!" in
+  Client.post ~ctx ~body (Uri.of_string "http://localhost:8080/repeat")
+  >>= fun (_resp, body) ->
+  Cohttp_lwt.Body.to_string body >>= fun str ->
+  Alcotest.(check string) "contents" str "Hello!" ;
+  Lwt.return_unit
+
+let test03 =
+  Alcotest_lwt.test_case "simple-https" `Quick @@ fun _sw () ->
+  unix_stack () >>= fun v ->
+  let ctx = Mimic.add stack v ctx in
+  Client.get ~ctx (Uri.of_string "https://localhost:4343/")
+  >>= fun (_resp, body) ->
+  Cohttp_lwt.Body.to_string body >>= fun str ->
+  Alcotest.(check string) "contents" str "Hello World!" ;
+  Lwt.return_unit
+
+let test04 =
+  Alcotest_lwt.test_case "repeat (https)" `Quick @@ fun _sw () ->
+  unix_stack () >>= fun v ->
+  let ctx = Mimic.add stack v ctx in
+  let body = Cohttp_lwt.Body.of_string "Secret Hello!" in
+  Client.post ~ctx ~body (Uri.of_string "https://localhost:4343/repeat")
+  >>= fun (_resp, body) ->
+  Cohttp_lwt.Body.to_string body >>= fun str ->
+  Alcotest.(check string) "contents" str "Secret Hello!" ;
+  Lwt.return_unit
+
+let test () =
+  Alcotest_lwt.run "smart" [ ("cohttp", [ test01; test02; test03; test04 ]) ]
+
+let () =
+  let fiber =
+    Lwt_switch.with_switch @@ fun stop ->
+    run_http_and_https_server ~request_handler stop >>= test >>= fun () ->
+    Lwt_switch.turn_off stop in
+  Lwt_main.run fiber

--- a/test/test_cohttp.ml
+++ b/test/test_cohttp.ml
@@ -54,8 +54,8 @@ let tls =
 
 let run_http_and_https_server ~request_handler stop =
   unix_stack () >>= fun stack ->
-  Paf.init ~port:8080 stack >>= fun http ->
-  Paf.init ~port:4343 stack >>= fun https ->
+  Paf.init ~port:9090 stack >>= fun http ->
+  Paf.init ~port:3434 stack >>= fun https ->
   let (`Initialized fiber0) =
     Paf.http ~stop ~error_handler ~request_handler http in
   let (`Initialized fiber1) =
@@ -100,7 +100,7 @@ let ctx =
              req Client.scheme;
              req stack;
              req Client.ipaddr;
-             dft Client.port 8080;
+             dft Client.port 9090;
            ]
          ~k:tcp_connect)
   |> Mimic.(
@@ -112,7 +112,7 @@ let ctx =
              dft tls null;
              req stack;
              req Client.ipaddr;
-             dft Client.port 4343;
+             dft Client.port 3434;
            ]
          ~k:tls_connect)
   |> Mimic.(fold Client.ipaddr Fun.[ req Client.domain_name ] ~k:resolver)
@@ -172,7 +172,7 @@ let test01 =
   Alcotest_lwt.test_case "simple-http" `Quick @@ fun _sw () ->
   unix_stack () >>= fun v ->
   let ctx = Mimic.add stack v ctx in
-  Client.get ~ctx (Uri.of_string "http://localhost:8080/")
+  Client.get ~ctx (Uri.of_string "http://localhost:9090/")
   >>= fun (_resp, body) ->
   Cohttp_lwt.Body.to_string body >>= fun str ->
   Alcotest.(check string) "contents" str "Hello World!" ;
@@ -183,7 +183,7 @@ let test02 =
   unix_stack () >>= fun v ->
   let ctx = Mimic.add stack v ctx in
   let body = Cohttp_lwt.Body.of_string "Hello!" in
-  Client.post ~ctx ~body (Uri.of_string "http://localhost:8080/repeat")
+  Client.post ~ctx ~body (Uri.of_string "http://localhost:9090/repeat")
   >>= fun (_resp, body) ->
   Cohttp_lwt.Body.to_string body >>= fun str ->
   Alcotest.(check string) "contents" str "Hello!" ;
@@ -193,7 +193,7 @@ let test03 =
   Alcotest_lwt.test_case "simple-https" `Quick @@ fun _sw () ->
   unix_stack () >>= fun v ->
   let ctx = Mimic.add stack v ctx in
-  Client.get ~ctx (Uri.of_string "https://localhost:4343/")
+  Client.get ~ctx (Uri.of_string "https://localhost:3434/")
   >>= fun (_resp, body) ->
   Cohttp_lwt.Body.to_string body >>= fun str ->
   Alcotest.(check string) "contents" str "Hello World!" ;
@@ -204,7 +204,7 @@ let test04 =
   unix_stack () >>= fun v ->
   let ctx = Mimic.add stack v ctx in
   let body = Cohttp_lwt.Body.of_string "Secret Hello!" in
-  Client.post ~ctx ~body (Uri.of_string "https://localhost:4343/repeat")
+  Client.post ~ctx ~body (Uri.of_string "https://localhost:3434/repeat")
   >>= fun (_resp, body) ->
   Cohttp_lwt.Body.to_string body >>= fun str ->
   Alcotest.(check string) "contents" str "Secret Hello!" ;


### PR DESCRIPTION
Two simple sub-libraries to help us to make a let's encrypt automatic provision for an unikernel with HTTP/AF - note that the CoHTTP layer is not yet ready.