### PR TITLE
Unfunctorize

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.16.0
+version = 0.17.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters=no

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -1,8 +1,7 @@
 (* (c) Hannes Menhert *)
 
-module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) = struct
-  module Client = Paf_cohttp.Make (Paf)
-  module Acme = Letsencrypt.Client.Make (Client)
+module Make (Time : Mirage_time.S) = struct
+  module Acme = Letsencrypt.Client.Make (Paf_cohttp)
 
   module Log = (val let src = Logs.Src.create "letsencrypt" in
                     Logs.src_log src : Logs.LOG)
@@ -86,5 +85,5 @@ module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) = struct
     Acme.sign_certificate ~ctx solver le sleep csr >|= fun certs ->
     `Single (certs, priv)
 
-  include Client
+  include Paf_cohttp
 end

--- a/lib/lE.mli
+++ b/lib/lE.mli
@@ -1,4 +1,4 @@
-module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) : sig
+module Make (Time : Mirage_time.S) : sig
   type configuration = {
     email : Emile.mailbox option;
     seed : string option;
@@ -14,14 +14,6 @@ module Make (Time : Mirage_time.S) (Paf : Paf_cohttp.PAF) : sig
     configuration ->
     Mimic.ctx ->
     (Tls.Config.own_cert, [> `Msg of string ]) result Lwt.t
-
-  val scheme : [ `HTTP | `HTTPS ] Mimic.value
-
-  val port : int Mimic.value
-
-  val domain_name : [ `host ] Domain_name.t Mimic.value
-
-  val ipaddr : Ipaddr.t Mimic.value
 
   val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
 end

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -1,287 +1,228 @@
-module type PAF = sig
-  type stack
-
-  val tcp_edn : (stack * Ipaddr.t * int) Mimic.value
-
-  val tls_edn :
-    ([ `host ] Domain_name.t option
-    * Tls.Config.client
-    * stack
-    * Ipaddr.t
-    * int)
-    Mimic.value
-
-  val request :
-    ?config:Httpaf.Config.t ->
-    ctx:Mimic.ctx ->
-    error_handler:
-      (Mimic.flow ->
-      (Ipaddr.t * int) option ->
-      Httpaf.Client_connection.error_handler) ->
-    response_handler:
-      ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
-    Httpaf.Request.t ->
-    ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
-end
-
 let ( <.> ) f g x = f (g x)
 
-module type S = sig
-  type stack
+let src = Logs.Src.create "paf-cohttp"
 
-  include Cohttp_lwt.S.Client with type ctx = Mimic.ctx
+module Log = (val Logs.src_log src : Logs.LOG)
 
-  val scheme : [ `HTTP | `HTTPS ] Mimic.value
+let scheme = Mimic.make ~name:"scheme"
 
-  val port : int Mimic.value
+let port = Mimic.make ~name:"port"
 
-  val domain_name : [ `host ] Domain_name.t Mimic.value
+let domain_name = Mimic.make ~name:"domain-name"
 
-  val ipaddr : Ipaddr.t Mimic.value
+let ipaddr = Mimic.make ~name:"ipaddr"
 
-  val tcp_edn : (stack * Ipaddr.t * int) Mimic.value
+let sleep = Mimic.make ~name:"sleep"
 
-  val tls_edn :
-    ([ `host ] Domain_name.t option
-    * Tls.Config.client
-    * stack
-    * Ipaddr.t
-    * int)
-    Mimic.value
+type ctx = Mimic.ctx
 
-  val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
-end
+let default_ctx = Mimic.empty
 
-module Make (Paf : PAF) : S with type stack = Paf.stack = struct
-  open Paf
+let httpaf_config = Mimic.make ~name:"httpaf-config"
 
-  let src = Logs.Src.create "paf-cohttp"
+let error_handler mvar flow edn err =
+  Lwt.async @@ fun () -> Lwt_mvar.put mvar (flow, edn, err)
 
-  module Log = (val Logs.src_log src : Logs.LOG)
+let response_handler mvar pusher _edn resp body =
+  let on_eof () = pusher None in
+  let rec on_read buf ~off ~len =
+    let str = Bigstringaf.substring buf ~off ~len in
+    pusher (Some str) ;
+    Httpaf.Body.schedule_read ~on_eof ~on_read body in
+  Httpaf.Body.schedule_read ~on_eof ~on_read body ;
+  Lwt.async @@ fun () -> Lwt_mvar.put mvar resp
 
-  type ctx = Mimic.ctx
+let rec unroll body stream =
+  let open Lwt.Infix in
+  Lwt_stream.get stream >>= function
+  | Some str ->
+      Log.debug (fun m -> m "Transmit to HTTP/AF: %S." str) ;
+      Httpaf.Body.write_string body str ;
+      unroll body stream
+  | None ->
+      Log.debug (fun m -> m "Close the HTTP/AF writer.") ;
+      Httpaf.Body.close_writer body ;
+      Lwt.return_unit
 
-  type stack = Paf.stack
+let transmit cohttp_body httpaf_body =
+  match cohttp_body with
+  | `Empty -> Httpaf.Body.close_writer httpaf_body
+  | `String str ->
+      Httpaf.Body.write_string httpaf_body str ;
+      Httpaf.Body.close_writer httpaf_body
+  | `Strings sstr ->
+      List.iter (Httpaf.Body.write_string httpaf_body) sstr ;
+      Httpaf.Body.close_writer httpaf_body
+  | `Stream stream -> Lwt.async @@ fun () -> unroll httpaf_body stream
 
-  let sexp_of_ctx _ctx = assert false
+exception Internal_server_error
 
-  let default_ctx = Mimic.empty
+exception Invalid_response_body_length of Httpaf.Response.t
 
-  let httpaf_config = Mimic.make ~name:"httpaf-config"
+exception Malformed_response of string
 
-  let error_handler mvar flow edn err =
-    Lwt.async @@ fun () -> Lwt_mvar.put mvar (flow, edn, err)
+let with_uri uri ctx =
+  let scheme_v =
+    match Uri.scheme uri with
+    | Some "http" -> Some `HTTP
+    | Some "https" -> Some `HTTPS
+    | _ -> None in
+  let port_v =
+    match (Uri.port uri, scheme_v) with
+    | Some port, _ -> Some port
+    | None, Some `HTTP -> Some 80
+    | None, Some `HTTPS -> Some 443
+    | _ -> None in
+  let domain_name_v, ipaddr_v =
+    match Uri.host uri with
+    | Some v -> (
+        match
+          (Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v)
+        with
+        | _, Ok v -> (None, Some v)
+        | Ok v, _ -> (Some v, None)
+        | _ -> (None, None))
+    | _ -> (None, None) in
+  let ctx =
+    Option.fold ~none:ctx ~some:(fun v -> Mimic.add scheme v ctx) scheme_v in
+  let ctx = Option.fold ~none:ctx ~some:(fun v -> Mimic.add port v ctx) port_v in
+  let ctx =
+    Option.fold ~none:ctx ~some:(fun v -> Mimic.add ipaddr v ctx) ipaddr_v in
+  let ctx =
+    Option.fold ~none:ctx
+      ~some:(fun v -> Mimic.add domain_name v ctx)
+      domain_name_v in
+  ctx
 
-  let response_handler mvar pusher _edn resp body =
-    let on_eof () = pusher None in
-    let rec on_read buf ~off ~len =
-      let str = Bigstringaf.substring buf ~off ~len in
-      pusher (Some str) ;
-      Httpaf.Body.schedule_read ~on_eof ~on_read body in
-    Httpaf.Body.schedule_read ~on_eof ~on_read body ;
-    Lwt.async @@ fun () -> Lwt_mvar.put mvar resp
+let with_host headers uri =
+  let hostname = Uri.host_with_default ~default:"localhost" uri in
+  let hostname =
+    match Uri.port uri with
+    | Some port -> Fmt.str "%s:%d" hostname port
+    | None -> hostname in
+  Httpaf.Headers.add_unless_exists headers "host" hostname
 
-  let rec unroll body stream =
-    let open Lwt.Infix in
-    Lwt_stream.get stream >>= function
-    | Some str ->
-        Log.debug (fun m -> m "Transmit to HTTP/AF: %S." str) ;
-        Httpaf.Body.write_string body str ;
-        unroll body stream
-    | None ->
-        Log.debug (fun m -> m "Close the HTTP/AF writer.") ;
-        Httpaf.Body.close_writer body ;
-        Lwt.return_unit
+let with_transfer_encoding ~chunked body headers =
+  match (chunked, body, Httpaf.Headers.get headers "content-length") with
+  | (None | Some false), _, Some _ -> headers
+  | Some true, _, (Some _ | None) | None, `Stream _, None ->
+      (* XXX(dinosaure): I'm not sure that the [Some _] was right. *)
+      Httpaf.Headers.add_unless_exists headers "transfer-encoding" "chunked"
+  | (None | Some false), `Empty, None ->
+      Httpaf.Headers.add_unless_exists headers "content-length" "0"
+  | (None | Some false), `String str, None ->
+      Httpaf.Headers.add_unless_exists headers "content-length"
+        (string_of_int (String.length str))
+  | (None | Some false), `Strings sstr, None ->
+      let len = List.fold_right (( + ) <.> String.length) sstr 0 in
+      Httpaf.Headers.add_unless_exists headers "content-length"
+        (string_of_int len)
+  | Some false, `Stream _, None ->
+      invalid_arg "Impossible to transfer a stream with a content-length value"
 
-  let transmit cohttp_body httpaf_body =
-    match cohttp_body with
-    | `Empty -> Httpaf.Body.close_writer httpaf_body
-    | `String str ->
-        Httpaf.Body.write_string httpaf_body str ;
-        Httpaf.Body.close_writer httpaf_body
-    | `Strings sstr ->
-        List.iter (Httpaf.Body.write_string httpaf_body) sstr ;
-        Httpaf.Body.close_writer httpaf_body
-    | `Stream stream -> Lwt.async @@ fun () -> unroll httpaf_body stream
+let call ?(ctx = default_ctx) ?headers
+    ?body:(cohttp_body = Cohttp_lwt.Body.empty) ?chunked meth uri =
+  Log.debug (fun m -> m "Fill the context with %a." Uri.pp uri) ;
+  let ctx = with_uri uri ctx in
+  let config =
+    match Mimic.get httpaf_config ctx with
+    | Some config -> config
+    | None -> Httpaf.Config.default in
+  let sleep =
+    match Mimic.get sleep ctx with
+    | Some sleep -> sleep
+    | None -> fun _ -> Lwt.return_unit
+    (* TODO *) in
+  let headers =
+    match headers with
+    | Some headers -> Httpaf.Headers.of_list (Cohttp.Header.to_list headers)
+    | None -> Httpaf.Headers.empty in
+  let headers = with_host headers uri in
+  let headers = with_transfer_encoding ~chunked cohttp_body headers in
+  let meth =
+    match meth with
+    | #Httpaf.Method.t as meth -> meth
+    | #Cohttp.Code.meth as meth -> `Other (Cohttp.Code.string_of_method meth)
+  in
+  let req = Httpaf.Request.create ~headers meth (Uri.path uri) in
+  let stream, pusher = Lwt_stream.create () in
+  let mvar_res = Lwt_mvar.create_empty () in
+  let mvar_err = Lwt_mvar.create_empty () in
+  let open Lwt.Infix in
+  Mimic.resolve ctx >>= function
+  | Error (#Mimic.error as err) ->
+      Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
+  | Ok flow -> (
+      let httpaf_body =
+        Paf.request ~sleep ~config flow ()
+          ~error_handler:(error_handler mvar_err)
+          ~response_handler:(response_handler mvar_res pusher)
+          req in
+      transmit cohttp_body httpaf_body ;
+      Log.debug (fun m -> m "Body transmitted.") ;
+      Lwt.pick
+        [
+          (Lwt_mvar.take mvar_res >|= fun res -> `Response res);
+          (Lwt_mvar.take mvar_err >|= fun err -> `Error err);
+        ]
+      >>= function
+      | `Error (flow, _, `Exn exn) ->
+          Mimic.close flow >>= fun () -> Lwt.fail exn
+      | `Error (flow, _, `Invalid_response_body_length resp) ->
+          Mimic.close flow >>= fun () ->
+          Lwt.fail (Invalid_response_body_length resp)
+      | `Error (flow, _, `Malformed_response err) ->
+          Mimic.close flow >>= fun () -> Lwt.fail (Malformed_response err)
+      | `Response resp ->
+          Log.debug (fun m -> m "Response received.") ;
+          let version =
+            match resp.Httpaf.Response.version with
+            | { Httpaf.Version.major = 1; minor = 0 } -> `HTTP_1_0
+            | { major = 1; minor = 1 } -> `HTTP_1_1
+            | { major; minor } -> `Other (Fmt.str "%d.%d" major minor) in
+          let status =
+            match
+              (resp.Httpaf.Response.status
+                :> [ Cohttp.Code.status | Httpaf.Status.t ])
+            with
+            | #Cohttp.Code.status as status -> status
+            | #Httpaf.Status.t as status -> `Code (Httpaf.Status.to_code status)
+          in
+          let encoding =
+            match meth with
+            | #Httpaf.Method.standard as meth -> (
+                match Httpaf.Response.body_length ~request_method:meth resp with
+                | `Chunked | `Close_delimited -> Cohttp.Transfer.Chunked
+                | `Error _err -> raise Internal_server_error
+                | `Fixed length -> Cohttp.Transfer.Fixed length)
+            | _ -> Cohttp.Transfer.Chunked in
+          let headers =
+            Cohttp.Header.of_list
+              (Httpaf.Headers.to_list resp.Httpaf.Response.headers) in
+          let resp =
+            Cohttp.Response.make ~version ~status ~encoding ~headers () in
+          Lwt.return (resp, `Stream stream))
 
-  exception Internal_server_error
+open Lwt.Infix
 
-  exception Invalid_response_body_length of Httpaf.Response.t
+let head ?ctx ?headers uri = call ?ctx ?headers `HEAD uri >|= fst
 
-  exception Malformed_response of string
+let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
 
-  let scheme = Mimic.make ~name:"scheme"
+let delete ?ctx ?body ?chunked ?headers uri =
+  call ?ctx ?body ?chunked ?headers `DELETE uri
 
-  let port = Mimic.make ~name:"port"
+let post ?ctx ?body ?chunked ?headers uri =
+  call ?ctx ?body ?chunked ?headers `POST uri
 
-  let domain_name = Mimic.make ~name:"domain-name"
+let put ?ctx ?body ?chunked ?headers uri =
+  call ?ctx ?body ?chunked ?headers `PUT uri
 
-  let ipaddr = Mimic.make ~name:"ipaddr"
+let patch ?ctx ?body ?chunked ?headers uri =
+  call ?ctx ?body ?chunked ?headers `PATCH uri
 
-  let tcp_edn = Paf.tcp_edn
+let post_form ?ctx:_ ?headers:_ ~params:_ _uri = assert false (* TODO *)
 
-  let tls_edn = Paf.tls_edn
+let callv ?ctx:_ _uri _stream = assert false (* TODO *)
 
-  let with_uri uri ctx =
-    let scheme_v =
-      match Uri.scheme uri with
-      | Some "http" -> Some `HTTP
-      | Some "https" -> Some `HTTPS
-      | _ -> None in
-    let port_v =
-      match (Uri.port uri, scheme_v) with
-      | Some port, _ -> Some port
-      | None, Some `HTTP -> Some 80
-      | None, Some `HTTPS -> Some 443
-      | _ -> None in
-    let domain_name_v, ipaddr_v =
-      match Uri.host uri with
-      | Some v -> (
-          match
-            (Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v)
-          with
-          | _, Ok v -> (None, Some v)
-          | Ok v, _ -> (Some v, None)
-          | _ -> (None, None))
-      | _ -> (None, None) in
-    let ctx =
-      Option.fold ~none:ctx ~some:(fun v -> Mimic.add scheme v ctx) scheme_v
-    in
-    let ctx =
-      Option.fold ~none:ctx ~some:(fun v -> Mimic.add port v ctx) port_v in
-    let ctx =
-      Option.fold ~none:ctx ~some:(fun v -> Mimic.add ipaddr v ctx) ipaddr_v
-    in
-    let ctx =
-      Option.fold ~none:ctx
-        ~some:(fun v -> Mimic.add domain_name v ctx)
-        domain_name_v in
-    ctx
-
-  let with_host headers uri =
-    let hostname = Uri.host_with_default ~default:"localhost" uri in
-    let hostname =
-      match Uri.port uri with
-      | Some port -> Fmt.str "%s:%d" hostname port
-      | None -> hostname in
-    Httpaf.Headers.add_unless_exists headers "host" hostname
-
-  let with_transfer_encoding ~chunked body headers =
-    match (chunked, body, Httpaf.Headers.get headers "content-length") with
-    | (None | Some false), _, Some _ -> headers
-    | Some true, _, (Some _ | None) | None, `Stream _, None ->
-        (* XXX(dinosaure): I'm not sure that the [Some _] was right. *)
-        Httpaf.Headers.add_unless_exists headers "transfer-encoding" "chunked"
-    | (None | Some false), `Empty, None ->
-        Httpaf.Headers.add_unless_exists headers "content-length" "0"
-    | (None | Some false), `String str, None ->
-        Httpaf.Headers.add_unless_exists headers "content-length"
-          (string_of_int (String.length str))
-    | (None | Some false), `Strings sstr, None ->
-        let len = List.fold_right (( + ) <.> String.length) sstr 0 in
-        Httpaf.Headers.add_unless_exists headers "content-length"
-          (string_of_int len)
-    | Some false, `Stream _, None ->
-        invalid_arg
-          "Impossible to transfer a stream with a content-length value"
-
-  let call ?(ctx = default_ctx) ?headers
-      ?body:(cohttp_body = Cohttp_lwt.Body.empty) ?chunked meth uri =
-    Log.debug (fun m -> m "Fill the context with %a." Uri.pp uri) ;
-    let ctx = with_uri uri ctx in
-    let config =
-      match Mimic.get httpaf_config ctx with
-      | Some config -> config
-      | None -> Httpaf.Config.default in
-    let headers =
-      match headers with
-      | Some headers -> Httpaf.Headers.of_list (Cohttp.Header.to_list headers)
-      | None -> Httpaf.Headers.empty in
-    let headers = with_host headers uri in
-    let headers = with_transfer_encoding ~chunked cohttp_body headers in
-    let meth =
-      match meth with
-      | #Httpaf.Method.t as meth -> meth
-      | #Cohttp.Code.meth as meth -> `Other (Cohttp.Code.string_of_method meth)
-    in
-    let req = Httpaf.Request.create ~headers meth (Uri.path uri) in
-    let stream, pusher = Lwt_stream.create () in
-    let mvar_res = Lwt_mvar.create_empty () in
-    let mvar_err = Lwt_mvar.create_empty () in
-    let open Lwt.Infix in
-    request ~config ~ctx ~error_handler:(error_handler mvar_err)
-      ~response_handler:(response_handler mvar_res pusher)
-      req
-    >>= function
-    | Error (#Mimic.error as err) ->
-        Lwt.fail (Failure (Fmt.str "%a" Mimic.pp_error err))
-    | Ok httpaf_body -> (
-        transmit cohttp_body httpaf_body ;
-        Log.debug (fun m -> m "Body transmitted.") ;
-        Lwt.pick
-          [
-            (Lwt_mvar.take mvar_res >|= fun res -> `Response res);
-            (Lwt_mvar.take mvar_err >|= fun err -> `Error err);
-          ]
-        >>= function
-        | `Error (flow, _, `Exn exn) ->
-            Mimic.close flow >>= fun () -> Lwt.fail exn
-        | `Error (flow, _, `Invalid_response_body_length resp) ->
-            Mimic.close flow >>= fun () ->
-            Lwt.fail (Invalid_response_body_length resp)
-        | `Error (flow, _, `Malformed_response err) ->
-            Mimic.close flow >>= fun () -> Lwt.fail (Malformed_response err)
-        | `Response resp ->
-            Log.debug (fun m -> m "Response received.") ;
-            let version =
-              match resp.Httpaf.Response.version with
-              | { Httpaf.Version.major = 1; minor = 0 } -> `HTTP_1_0
-              | { major = 1; minor = 1 } -> `HTTP_1_1
-              | { major; minor } -> `Other (Fmt.str "%d.%d" major minor) in
-            let status =
-              match
-                (resp.Httpaf.Response.status
-                  :> [ Cohttp.Code.status | Httpaf.Status.t ])
-              with
-              | #Cohttp.Code.status as status -> status
-              | #Httpaf.Status.t as status ->
-                  `Code (Httpaf.Status.to_code status) in
-            let encoding =
-              match meth with
-              | #Httpaf.Method.standard as meth -> (
-                  match
-                    Httpaf.Response.body_length ~request_method:meth resp
-                  with
-                  | `Chunked | `Close_delimited -> Cohttp.Transfer.Chunked
-                  | `Error _err -> raise Internal_server_error
-                  | `Fixed length -> Cohttp.Transfer.Fixed length)
-              | _ -> Cohttp.Transfer.Chunked in
-            let headers =
-              Cohttp.Header.of_list
-                (Httpaf.Headers.to_list resp.Httpaf.Response.headers) in
-            let resp =
-              Cohttp.Response.make ~version ~status ~encoding ~headers () in
-            Lwt.return (resp, `Stream stream))
-
-  open Lwt.Infix
-
-  let head ?ctx ?headers uri = call ?ctx ?headers `HEAD uri >|= fst
-
-  let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
-
-  let delete ?ctx ?body ?chunked ?headers uri =
-    call ?ctx ?body ?chunked ?headers `DELETE uri
-
-  let post ?ctx ?body ?chunked ?headers uri =
-    call ?ctx ?body ?chunked ?headers `POST uri
-
-  let put ?ctx ?body ?chunked ?headers uri =
-    call ?ctx ?body ?chunked ?headers `PUT uri
-
-  let patch ?ctx ?body ?chunked ?headers uri =
-    call ?ctx ?body ?chunked ?headers `PATCH uri
-
-  let post_form ?ctx:_ ?headers:_ ~params:_ _uri = assert false (* TODO *)
-
-  let callv ?ctx:_ _uri _stream = assert false (* TODO *)
-end
+let sexp_of_ctx _ctx = assert false

--- a/lib/paf_cohttp.mli
+++ b/lib/paf_cohttp.mli
@@ -1,53 +1,13 @@
-module type PAF = sig
-  type stack
+val scheme : [ `HTTP | `HTTPS ] Mimic.value
 
-  val tcp_edn : (stack * Ipaddr.t * int) Mimic.value
+val port : int Mimic.value
 
-  val tls_edn :
-    ([ `host ] Domain_name.t option
-    * Tls.Config.client
-    * stack
-    * Ipaddr.t
-    * int)
-    Mimic.value
+val domain_name : [ `host ] Domain_name.t Mimic.value
 
-  val request :
-    ?config:Httpaf.Config.t ->
-    ctx:Mimic.ctx ->
-    error_handler:
-      (Mimic.flow ->
-      (Ipaddr.t * int) option ->
-      Httpaf.Client_connection.error_handler) ->
-    response_handler:
-      ((Ipaddr.t * int) option -> Httpaf.Client_connection.response_handler) ->
-    Httpaf.Request.t ->
-    ([ `write ] Httpaf.Body.t, [> Mimic.error ]) result Lwt.t
-end
+val ipaddr : Ipaddr.t Mimic.value
 
-module type S = sig
-  type stack
+val sleep : (int64 -> unit Lwt.t) Mimic.value
 
-  include Cohttp_lwt.S.Client with type ctx = Mimic.ctx
+val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
 
-  val scheme : [ `HTTP | `HTTPS ] Mimic.value
-
-  val port : int Mimic.value
-
-  val domain_name : [ `host ] Domain_name.t Mimic.value
-
-  val ipaddr : Ipaddr.t Mimic.value
-
-  val tcp_edn : (stack * Ipaddr.t * int) Mimic.value
-
-  val tls_edn :
-    ([ `host ] Domain_name.t option
-    * Tls.Config.client
-    * stack
-    * Ipaddr.t
-    * int)
-    Mimic.value
-
-  val with_uri : Uri.t -> Mimic.ctx -> Mimic.ctx
-end
-
-module Make (Paf : PAF) : S with type stack = Paf.stack
+include Cohttp_lwt.S.Client with type ctx = Mimic.ctx

--- a/test/dune
+++ b/test/dune
@@ -6,14 +6,13 @@
 (executable
  (name simple_server)
  (modules simple_server)
- (libraries logs.fmt fmt.tty mirage-crypto-rng.unix mirage-time-unix
-   tcpip.stack-socket paf))
+ (libraries logs.fmt fmt.tty mirage-crypto-rng.unix tcpip.stack-socket paf))
 
 (library
  (name simple_client)
  (modules simple_client)
- (libraries ptime.clock.os logs.fmt fmt.tty uri mirage-crypto-rng.unix
-   mirage-time-unix tcpip.stack-socket paf))
+ (libraries lwt.unix ptime.clock.os logs.fmt fmt.tty uri
+   mirage-crypto-rng.unix tcpip.stack-socket paf))
 
 (executable
  (name clients)
@@ -31,8 +30,8 @@
 (executable
  (name test_cohttp)
  (modules test_cohttp)
- (libraries fmt.tty logs.fmt alcotest-lwt mirage-time-unix tcpip.stack-socket
-   cohttp-lwt paf.cohttp mirage-crypto-rng.unix))
+ (libraries fmt.tty logs.fmt alcotest-lwt tcpip.stack-socket cohttp-lwt
+   paf.cohttp mirage-crypto-rng.unix))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
The goal of this PR is to _unfunctorize_ `paf` and specially `paf.cohttp` to be able to plug it into `ocaml-git` without further updates on all the stack. Indeed, the next version of `conduit` will shift with 2 functors the complete stack (from `conduit` to `irmin`). To avoid such huge change and be relax about dependencies, this PR paves a new way to definitely delete `conduit` from the whole stack.

It comes with a breaking-changes where:
- the `sleep` function should be pass with `mimic`
- `Paf_cohttp` is not a functor anymore and can be used as is directly

The first point is the ugly part of this PR and should be fixed by MirageOS/implicit transitive deps/`Time` module available as is in the context of MirageOS. `sleep` exists mostly due to a different behavior between `mirage-tcpip` and the host TCP/IP stack (we can consider the existence of it as a side effect of something wrong about `mirage-tcpip`).

The second point is about the usage of `cohttp`/`git`/`irmin` for `irmin-mirage-git`. The stack highly relies on the fact that `Git_mirage_cohttp`/`Cohttp_mirage` can provide the client part without any functors. On such design, `conduit` is the way to _apply_/_inject_ the underlying module (`TCP/IP` or `TLS`)  according the given `Uri.t`.

By design, `mimic` was done in the same way (but allows a real ability to choose the TLS certificate if we want to use a TLS connection - eg. `https://...`). So, we are definitely able (if we remove the `Mirage_time.S` functor - see the first point) to _unfunctorize_ `Paf_cohttp`. By this way, and by transitivity, the usage of `Git_mirage` does not require functors too and we don't need to shift the `irmin-mirage-git` functor with some others arguments to use it then.

Such way to update the stack does not imply an update of the mirage tool at the end (and `functoria` descriptions).

The final goal is to unlock the ability to upgrade the __whole__ stack (including DNS) to `Mirage_stack.V4V6`...