### PR TITLE
update to X509 0.13.0 API

### DIFF
--- a/paf.opam
+++ b/paf.opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-stack"
   "mirage-time"
   "httpaf"
-  "tls-mirage"
+  "tls-mirage" {>= "0.13.0"}
   "mimic"
   "cohttp-lwt"
   "letsencrypt"
@@ -38,6 +38,7 @@ depends: [
   "faraday" {>= "0.7.2"}
   "ipaddr" {>= "5.0.1"}
   "tls" {>= "0.13.0"}
+  "x509" {>= "0.13.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]


### PR DESCRIPTION
the Signing_request.create can fail nowadays (since sign can fail). Earlier this raised an exception (deep inside Mirage_crypto_pk.Rsa.sign)...