### PR TITLE
Refactorize the code on a common impl. needed to manipulate a Mirage_flow.S/Mimic.flow

### DIFF
--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -60,8 +60,6 @@ module type RUNTIME = sig
   val shutdown : t -> unit
 end
 
-exception Flow of Mimic.error
-
 type 'conn runtime = (module RUNTIME with type t = 'conn)
 
 type impl = Runtime : 'conn runtime * 'conn -> impl

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -60,8 +60,6 @@ let failf fmt = Format.kasprintf (fun err -> raise (Failure err)) fmt
 let error_handler wk _ (err : Alpn.client_error) =
   Lwt.wakeup_later wk (err :> [ `Body of string | `Done | Alpn.client_error ]) ;
   match err with
-  | `Exn (Paf.Flow err) ->
-      failf "Impossible to start a transmission: %a" Mimic.pp_error err
   | `Invalid_response_body_length_v1 _ | `Invalid_response_body_length_v2 _ ->
       failf "Invalid response body-length"
   | `Malformed_response _ -> failf "Malformed response"

--- a/test/simple_server.ml
+++ b/test/simple_server.ml
@@ -118,19 +118,8 @@ let request_handler large (ip, port) reqd =
       http_large large (ip, port) (Reqd.request_body reqd) oc
   | _ -> assert false
 
-let error_handler (ip, port) ?request:_ error respond =
-  let open Httpaf in
+let error_handler _ ?request:_ error _respond =
   match error with
-  | `Exn (Paf.Flow err) ->
-      let contents =
-        Fmt.strf "Internal server error from <%a:%d>: %a" Ipaddr.pp ip port
-          Mimic.pp_error err in
-      let headers =
-        Headers.of_list
-          [ ("content-length", string_of_int (String.length contents)) ] in
-      let body = respond headers in
-      Body.write_string body contents ;
-      Body.close_writer body
   | `Exn _exn -> Printexc.print_backtrace stderr
   | `Bad_gateway -> Fmt.epr "Got a bad gateway error.\n%!"
   | `Bad_request -> Fmt.epr "Got a bad request error.\n%!"


### PR DESCRIPTION
Less code is better and fix a spurious situation when HTTP/AF does not consume nor finalize a connection.