### PR TITLE
paf-le: avoid astring dependency

### DIFF
--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -262,9 +262,7 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
     Log.debug (fun m ->
         m "Let's encrypt request handler for %a:%d" Ipaddr.pp ipaddr port) ;
     let req = Httpaf.Reqd.request reqd in
-    match
-      Astring.String.cuts ~sep:"/" ~empty:false req.Httpaf.Request.target
-    with
+    match String.split_on_char '/' req.Httpaf.Request.target with
     | [ p1; p2; token ]
       when String.equal p1 (fst prefix) && String.equal p2 (snd prefix) -> (
         match Hashtbl.find_opt tokens token with

--- a/paf-cohttp.opam
+++ b/paf-cohttp.opam
@@ -24,6 +24,7 @@ depends: [
   "tcpip"             {with-test}
   "uri"               {with-test}
   "lwt"               {with-test}
+  "astring"           {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/test/dune
+++ b/test/dune
@@ -38,7 +38,7 @@
  (name test_cohttp)
  (modules test_cohttp)
  (libraries mirage-time-unix fmt.tty logs.fmt alcotest-lwt tcpip.stack-socket
-   cohttp-lwt paf-cohttp paf.mirage mirage-crypto-rng.unix))
+   cohttp-lwt paf-cohttp paf.mirage mirage-crypto-rng.unix astring))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
paf-cohttp: add astring with-test dependency

this makes paf compatible with domain-name 0.3.1