### PR TITLE
Avoid rresult dependency

### DIFF
--- a/lib/alpn.ml
+++ b/lib/alpn.ml
@@ -94,7 +94,7 @@ let service info ~error_handler ~request_handler accept close =
         let conn = H2.Server_connection.create ~error_handler request_handler in
         Lwt.return_ok (flow, Paf.Runtime ((module H2.Server_connection), conn))
     | Some protocol ->
-        Lwt.return_error (Rresult.R.msgf "Invalid protocol %S." protocol) in
+        Lwt.return_error (`Msg (Fmt.str "Invalid protocol %S." protocol)) in
   Paf.service connection accept close
 
 type client_error =
@@ -142,4 +142,4 @@ let run ~sleep ?alpn ~error_handler ~response_handler edn request flow =
       Lwt.return_ok (Body (HTTP_1_1, body))
   | Some protocol, _ ->
       Lwt.return_error
-        (Rresult.R.msgf "Invalid Application layer protocol: %S" protocol)
+        (`Msg (Fmt.str "Invalid Application layer protocol: %S" protocol))

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name paf)
  (public_name paf)
  (modules paf)
- (libraries rresult faraday bigstringaf ke mimic))
+ (libraries faraday bigstringaf ke mimic))
 
 (library
  (name alpn)

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -48,7 +48,7 @@ let with_uri uri ctx =
     match Uri.host uri with
     | Some v -> (
         match
-          (Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v)
+          (Result.bind (Domain_name.of_string v) Domain_name.host, Ipaddr.of_string v)
         with
         | _, Ok v -> (None, Some v)
         | Ok v, _ -> (Some v, None)
@@ -321,10 +321,10 @@ module Make (Time : Mirage_time.S) (Stack : Mirage_stack.V4V6) = struct
       | `Closed -> pp_write_error ppf `Closed
 
     let write stack cs =
-      write stack cs >|= Rresult.R.reword_error (fun err -> `Write_error err)
+      write stack cs >|= Result.map_error (fun err -> `Write_error err)
 
     let writev stack css =
-      writev stack css >|= Rresult.R.reword_error (fun err -> `Write_error err)
+      writev stack css >|= Result.map_error (fun err -> `Write_error err)
 
     type nonrec write_error =
       [ `Error of error | `Write_error of write_error | `Closed ]

--- a/lib/lE.ml
+++ b/lib/lE.ml
@@ -48,7 +48,8 @@ let with_uri uri ctx =
     match Uri.host uri with
     | Some v -> (
         match
-          (Result.bind (Domain_name.of_string v) Domain_name.host, Ipaddr.of_string v)
+          ( Result.bind (Domain_name.of_string v) Domain_name.host,
+            Ipaddr.of_string v )
         with
         | _, Ok v -> (None, Some v)
         | Ok v, _ -> (Some v, None)

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -316,7 +316,6 @@ and ('t, 'flow, 'error) posix = {
 
 let service connection accept close = Service { accept; connection; close }
 
-open Rresult
 open Lwt.Infix
 
 let serve_when_ready :

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -76,7 +76,7 @@ let with_uri uri ctx =
     match Uri.host uri with
     | Some v -> (
         match
-          (Rresult.(Domain_name.(of_string v >>= host)), Ipaddr.of_string v)
+          (Result.bind (Domain_name.of_string v) Domain_name.host, Ipaddr.of_string v)
         with
         | _, Ok v -> (None, Some v)
         | Ok v, _ -> (Some v, None)

--- a/lib/paf_cohttp.ml
+++ b/lib/paf_cohttp.ml
@@ -76,7 +76,8 @@ let with_uri uri ctx =
     match Uri.host uri with
     | Some v -> (
         match
-          (Result.bind (Domain_name.of_string v) Domain_name.host, Ipaddr.of_string v)
+          ( Result.bind (Domain_name.of_string v) Domain_name.host,
+            Ipaddr.of_string v )
         with
         | _, Ok v -> (None, Some v)
         | Ok v, _ -> (Some v, None)

--- a/paf.opam
+++ b/paf.opam
@@ -15,7 +15,6 @@ depends: [
   "mirage-time"
   "tls-mirage" {>= "0.15.0"}
   "mimic"
-  "rresult"
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -148,7 +148,7 @@ let run uri =
     | Some host ->
     match
       ( Ipaddr.of_string host,
-        Rresult.(Domain_name.of_string host >>= Domain_name.host) )
+        Result.bind (Domain_name.of_string host) Domain_name.host )
     with
     | Ok v0, Ok v1 ->
         (ctx |> Mimic.add ipaddr v0 |> Mimic.add domain_name v1, Some host)

--- a/test/test_alpn.ml
+++ b/test/test_alpn.ml
@@ -1,4 +1,3 @@
-open Rresult
 open Lwt.Infix
 
 let ( <.> ) f g x = f (g x)
@@ -95,7 +94,7 @@ let service ~request_handler () =
         let edn = Tcpip_stack_socket.V4V6.TCP.dst flow in
         P.TLS.server_of_flow tls flow >>= function
         | Ok flow -> Lwt.return_ok (edn, flow)
-        | Error err -> Lwt.return_error (R.msgf "%a" P.TLS.pp_write_error err))
+        | Error err -> Lwt.return_error (`Msg (Fmt.str "%a" P.TLS.pp_write_error err)))
   and close = P.close in
   Alpn.service info ~error_handler ~request_handler accept close
 

--- a/test/test_alpn.ml
+++ b/test/test_alpn.ml
@@ -94,7 +94,8 @@ let service ~request_handler () =
         let edn = Tcpip_stack_socket.V4V6.TCP.dst flow in
         P.TLS.server_of_flow tls flow >>= function
         | Ok flow -> Lwt.return_ok (edn, flow)
-        | Error err -> Lwt.return_error (`Msg (Fmt.str "%a" P.TLS.pp_write_error err)))
+        | Error err ->
+            Lwt.return_error (`Msg (Fmt.str "%a" P.TLS.pp_write_error err)))
   and close = P.close in
   Alpn.service info ~error_handler ~request_handler accept close
 

--- a/unikernel/client/unikernel.ml
+++ b/unikernel/client/unikernel.ml
@@ -34,7 +34,7 @@ module Make
   module Client = Paf_cohttp
   module Nss = Ca_certs_nss.Make(Pclock)
 
-  let authenticator = Rresult.R.failwith_error_msg (Nss.authenticator ())
+  let authenticator = Result.get_ok (Nss.authenticator ())
   let default_tls_cfg = Tls.Config.client ~authenticator ()
 
   let stack = Mimic.make ~name:"stack"

--- a/unikernel/server/unikernel.ml
+++ b/unikernel/server/unikernel.ml
@@ -22,7 +22,7 @@ module Make
   module Nss = Ca_certs_nss.Make(Pclock)
   module Letsencrypt = LE.Make(Time)(Stack)
 
-  let authenticator = Rresult.R.failwith_error_msg (Nss.authenticator ())
+  let authenticator = Result.get_ok (Nss.authenticator ())
 
   let error_handler _ ?request:_ _ _ = ()
 
@@ -60,8 +60,8 @@ module Make
         (fun _ -> request_handler) in
       let `Initialized th = Paf.serve service t in th
 
-  let host v = let open Rresult in
-    Domain_name.of_string v >>= Domain_name.host
+  let host v =
+    Result.bind (Domain_name.of_string v) Domain_name.host
 
   let cfg ?port ?email ?hostname ?seed ?certificate_seed = function
     | false -> HTTP (Option.value ~default:80 port)
@@ -71,8 +71,8 @@ module Make
       | None -> failwith "Missing hostname"
 
   let start _console _random _time _mclock _pclock stackv4v6 =
-    let email = Option.bind (Key_gen.email ()) (Rresult.R.to_option <.> Emile.of_string) in
-    let hostname = Option.bind (Key_gen.hostname ()) (Rresult.R.(to_option <.> host)) in
+    let email = Option.bind (Key_gen.email ()) (Result.to_option <.> Emile.of_string) in
+    let hostname = Option.bind (Key_gen.hostname ()) (Result.to_option <.> host) in
     let cfg = cfg ?port:(Key_gen.port ())
                   ?email
                   ?hostname


### PR DESCRIPTION
Since it is all OCaml >= 4.08.0 and from rresult description "OCaml 4.08 provides the Stdlib.Result module which you should prefer to Rresult.", this PR removes the usage of Rresult and uses Result instead. The first commit reverts #46, the second removes the usage of rresult.