### PR TITLE
unikernel: since Paf.http_service now receives a 'flow -> dst -> handler' as second argument, strip the flow from LE

### DIFF
--- a/unikernel/server/unikernel.ml
+++ b/unikernel/server/unikernel.ml
@@ -28,7 +28,10 @@ module Make
 
   let get_certificate ?(production= false) cfg stackv4v6 =
     Paf.init ~port:80 (Stack.tcp stackv4v6) >>= fun t ->
-    let service = Paf.http_service ~error_handler Letsencrypt.request_handler in
+    let service =
+      Paf.http_service ~error_handler
+        (fun _flow -> Letsencrypt.request_handler)
+    in
     Lwt_switch.with_switch @@ fun stop ->
     let `Initialized th = Paf.serve ~stop service t in
     let ctx = Letsencrypt.ctx


### PR DESCRIPTION
another option would be to adapt the lE module, but that requires another release...