### PR TITLE
Separate tcp connection (accept) from tls connection (connect)

### DIFF
--- a/lib/alpn.ml
+++ b/lib/alpn.ml
@@ -66,7 +66,7 @@ let error_handler_v2 edn f ?request error
     | _ -> assert false in
   f edn ?request (error :> server_error) response
 
-let service info ~error_handler ~request_handler accept close =
+let service info ~error_handler ~request_handler connect accept close =
   let connection flow =
     match info.alpn flow with
     | Some "http/1.0" | Some "http/1.1" | None ->
@@ -87,7 +87,7 @@ let service info ~error_handler ~request_handler accept close =
         Lwt.return_ok (flow, Paf.Runtime ((module H2.Server_connection), conn))
     | Some protocol ->
         Lwt.return_error (`Msg (Fmt.str "Invalid protocol %S." protocol)) in
-  Paf.service connection accept close
+  Paf.service connection connect accept close
 
 type client_error =
   [ `Exn of exn

--- a/lib/alpn.mli
+++ b/lib/alpn.mli
@@ -66,14 +66,15 @@ type 'flow info = {
     ]} *)
 
 val service :
-  'flow info ->
+  'connected_flow info ->
   error_handler:
     (string -> ?request:request -> server_error -> (headers -> body) -> unit) ->
   request_handler:(string -> reqd -> unit) ->
+  ('flow -> ('connected_flow, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t) ->
   ('t -> ('flow, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t) ->
   ('t -> unit Lwt.t) ->
   't Paf.service
-(** [service info ~error_handler ~request_handler accept close] creates a new
+(** [service info ~error_handler ~request_handler connect accept close] creates a new
     {!type:Paf.service} over the {i socket} ['t]. From the given implementation
     of [accept] and [close], we are able to instantiate the {i main loop}. Then,
     from the given [info], we extract informations such the application layer

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -73,7 +73,8 @@ val run : 'conn runtime -> sleep:sleep -> 'conn -> Mimic.flow -> unit Lwt.t
 type 't service
 
 val service :
-  ('flow -> (Mimic.flow * impl, 'error) result Lwt.t) ->
+  ('connected_flow -> (Mimic.flow * impl, 'error) result Lwt.t) ->
+  ('flow -> ('connected_flow, 'error) result Lwt.t) ->
   ('t -> ('flow, ([> `Closed ] as 'error)) result Lwt.t) ->
   ('t -> unit Lwt.t) ->
   't service


### PR DESCRIPTION
Currently, paf's main loop `serve_when_ready` waits on the `accept` handler to complete before  sending the flow to the service's handler. In our situation, the service is alpn and requires a tls flow, meaning that `accept` has to handle the tcp connection and the tls handshake before giving control to the service. In the meantime it cannot accept new connections. 

In particular this is a big issue when someone connects without sending data, or when the accept function raises an exception, because it either stalls the loop, or break it. 

Instead this PR proposes to separate the TCP accept from the TLS connection handshake (connect). This means that the service now has two flow types, a `'flow` and a `'connected_flow`. The first one is `TCP.flow` and the second one is `TLS.flow`. A `connect` function is introduced to setup the `'connected_flow` given a `'flow`. For HTTPS it is something using `TLS.server_of_flow`, for HTTP it's simply `Lwt.return_ok` as nothing additional has to be done.

I've deployed the patch on `next.mirage.io` to see how it performs. The naming could probably be better because `connect` and `connection` in the `Service` type are quite close in meaning. 