### PR TITLE
Do the TLS handshake in an asynchronous task to avoid blocking the service

### DIFF
--- a/lib/alpn.ml
+++ b/lib/alpn.ml
@@ -62,7 +62,7 @@ let error_handler_v2 edn f ?request error
     | _ -> assert false in
   f edn ?request (error :> server_error) response
 
-let service info ~error_handler ~request_handler accept close =
+let service info ~error_handler ~request_handler connect accept close =
   let connection flow =
     match info.alpn flow with
     | Some "http/1.0" | Some "http/1.1" | None ->
@@ -83,7 +83,7 @@ let service info ~error_handler ~request_handler accept close =
         Lwt.return_ok (flow, Paf.Runtime ((module H2.Server_connection), conn))
     | Some protocol ->
         Lwt.return_error (`Msg (Fmt.str "Invalid protocol %S." protocol)) in
-  Paf.service connection accept close
+  Paf.service connection connect accept close
 
 type client_error =
   [ `Exn of exn

--- a/lib/alpn.mli
+++ b/lib/alpn.mli
@@ -66,10 +66,11 @@ val service :
   error_handler:
     (string -> ?request:request -> server_error -> (headers -> body) -> unit) ->
   request_handler:(string -> reqd -> unit) ->
-  ('t -> ('flow, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t) ->
+  ('socket -> ('flow, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t) ->
+  ('t -> ('socket, ([> `Closed | `Msg of string ] as 'error)) result Lwt.t) ->
   ('t -> unit Lwt.t) ->
   't Paf.service
-(** [service info ~error_handler ~request_handler accept close] creates a new
+(** [service info ~error_handler ~request_handler connect accept close] creates a new
     {!type:Paf.service} over the {i socket} ['t]. From the given implementation
     of [accept] and [close], we are able to instantiate the {i main loop}. Then,
     from the given [info], we extract informations such the application layer

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -302,31 +302,33 @@ type impl = Runtime : 'conn runtime * 'conn -> impl
 
 type 't service =
   | Service : {
-      accept : 't -> ('flow, ([> `Closed ] as 'error)) result Lwt.t;
+      accept : 't -> ('socket, ([> `Closed ] as 'error)) result Lwt.t;
+      handshake : 'socket -> ('flow, ([> `Closed ] as 'error)) result Lwt.t;
       connection : 'flow -> (Mimic.flow * impl, 'error) result Lwt.t;
       close : 't -> unit Lwt.t;
     }
       -> 't service
 
-and ('t, 'flow, 'error) posix = {
-  accept : 't -> ('flow, 'error) result Lwt.t;
+and ('t, 'socket, 'flow, 'error) posix = {
+  accept : 't -> ('socket, 'error) result Lwt.t;
+  handshake : 'socket -> ('flow, 'error) result Lwt.t;
   close : 't -> unit Lwt.t;
 }
   constraint 'error = [> `Closed ]
 
-let service connection accept close = Service { accept; connection; close }
+let service connection handshake accept close = Service { accept; connection; handshake; close }
 
 open Lwt.Infix
 
 let serve_when_ready :
-    type t flow.
-    (t, flow, _) posix ->
+    type t socket flow.
+    (t, socket , flow, _) posix ->
     ?stop:Lwt_switch.t ->
     handler:(flow -> unit Lwt.t) ->
     t ->
     [ `Initialized of unit Lwt.t ] =
  fun service ?stop ~handler t ->
-  let { accept; close } = service in
+  let { accept; handshake; close } = service in
   `Initialized
     (let switched_off =
        let t, u = Lwt.wait () in
@@ -336,9 +338,16 @@ let serve_when_ready :
        t in
      let rec loop () =
        accept t >>= function
-       | Ok flow ->
-           Lwt.async (fun () -> handler flow) ;
-           Lwt.pause () >>= loop
+       | Ok socket ->
+         Lwt.async (fun () -> (handshake socket >>= function
+         | Ok flow -> handler flow
+         | Error `Closed ->
+           Logs.info (fun m -> m "Connection closed by peer");
+           Lwt.return ()
+         | Error _err ->
+           Logs.err (fun m -> m "Got an error from a TCP/IP connection.") ;
+           Lwt.return ()));
+           loop ()
        | Error `Closed -> Lwt.return_error `Closed
        | Error _ -> Lwt.pause () >>= loop in
      let stop_result =
@@ -353,12 +362,13 @@ let server : type t. t runtime -> sleep:sleep -> t -> Mimic.flow -> unit Lwt.t =
   Server.server ~sleep conn flow
 
 let serve ~sleep ?stop service t =
-  let (Service { accept; connection; close }) = service in
+  let (Service { accept; handshake; connection; close }) = service in
   let handler flow =
     connection flow >>= function
-    | Ok (flow, Runtime (runtime, conn)) -> server runtime ~sleep conn flow
+    | Ok (flow, Runtime (runtime, conn)) ->
+      server runtime ~sleep conn flow
     | Error _ -> Lwt.return_unit in
-  serve_when_ready ?stop ~handler { accept; close } t
+  serve_when_ready ?stop ~handler { accept; handshake; close } t
 
 let run : type t. t runtime -> sleep:sleep -> t -> Mimic.flow -> unit Lwt.t =
  fun (module Runtime) ~sleep conn flow ->

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -73,7 +73,8 @@ val run : 'conn runtime -> sleep:sleep -> 'conn -> Mimic.flow -> unit Lwt.t
 type 't service
 
 val service :
-  ('flow -> (Mimic.flow * impl, 'error) result Lwt.t) ->
+  ('connected_flow -> (Mimic.flow * impl, 'error) result Lwt.t) ->
+  ('flow -> ('connected_flow, 'error) result Lwt.t) ->
   ('t -> ('flow, ([> `Closed ] as 'error)) result Lwt.t) ->
   ('t -> unit Lwt.t) ->
   't service

--- a/lib/paf_mirage.ml
+++ b/lib/paf_mirage.ml
@@ -200,29 +200,27 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) :
       in
       Lwt.return_ok
         (R.T flow, Paf.Runtime ((module Httpaf.Server_connection), conn)) in
-    Paf.service connection accept close
+    Paf.service connection Lwt.return_ok accept close
 
   let https_service ~tls ?config ~error_handler request_handler =
     let module R = (val Mimic.repr tls_protocol) in
-    let accept t =
-      accept t >>= function
-      | Error _ as err -> Lwt.return err
-      | Ok flow -> (
-          let ((ipaddr, port) as dst) = Stack.TCP.dst flow in
-          TLS.server_of_flow tls flow >>= function
-          | Ok flow -> Lwt.return_ok (dst, flow)
-          | Error `Closed ->
-              (* XXX(dinosaure): be care! [`Closed] at this stage does not mean
-               * that the bound socket is closed but the socket with the peer is
-               * closed. *)
-              Lwt.return_error (`Write `Closed)
-          | Error err ->
-              Log.err (fun m ->
-                  m
-                    "Got an error when we try to connect to the client (TLS) \
-                     to %a:%d: %a"
-                    Ipaddr.pp ipaddr port TLS.pp_write_error err) ;
-              Stack.TCP.close flow >>= fun () -> Lwt.return_error err) in
+    let handshake flow =
+      let ((ipaddr, port) as dst) = Stack.TCP.dst flow in
+      TLS.server_of_flow tls flow >>= function
+      | Ok flow -> Lwt.return_ok (dst, flow)
+      | Error `Closed ->
+          (* XXX(dinosaure): be care! [`Closed] at this stage does not mean
+           * that the bound socket is closed but the socket with the peer is
+           * closed. *)
+          Lwt.return_error (`Write `Closed)
+      | Error err ->
+        Log.err (fun m ->
+            m
+              "Got an error when we try to connect to the client (TLS) \
+               to %a:%d: %a"
+              Ipaddr.pp ipaddr port TLS.pp_write_error err) ;
+          Stack.TCP.close flow >>= fun () -> Lwt.return_error err
+    in
     let connection (dst, flow) =
       let error_handler = error_handler dst in
       let request_handler = request_handler flow dst in
@@ -231,7 +229,7 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) :
       in
       Lwt.return_ok
         (R.T flow, Paf.Runtime ((module Httpaf.Server_connection), conn)) in
-    Paf.service connection accept close
+    Paf.service connection handshake accept close
 
   let serve ?stop service t = Paf.serve ~sleep:Time.sleep_ns ?stop service t
 


### PR DESCRIPTION
Would it be possible for you to create a 0.0.8 branch, merge this commit in there, and release a 0.0.8.1? Thanks a lot.

This may happen when a partial TLS handshake is being done by one client, which
blocks any other clients from establishing a TLS connection (since all is done
within the main task).

Reproduce by running:
echo 1603034800 | perl -e 'print pack "H*", <STDIN>' | nc $host 443
and attempting to establish a https connection to the same host

Adapted 8684c715c90713a3cb3e59bc2bc71c93b13e24b1 to 0.0.8

separate tcp connection from tls connection

Co-Authored-By: Lucas Pluvinage <lucas@tarides.com>