### PR TITLE
Enable being able to avoid interruptions of the HTTP & HTTPS services when renewing a letsencrypt certificate

### DIFF
--- a/lib/lE.mli
+++ b/lib/lE.mli
@@ -18,7 +18,7 @@
         Paf.init ~port:80 (Stack.tcp stackv4v6) >>= fun t ->
         let service = Paf.http_service
           ~error_handler:ignore_error
-          (fun _ -> LE.request_handler) in
+          (fun _ -> LE.request_handler ~fallback:None) in
         let stop = Lwt_switch.create () in
         let `Initialized th0 = Paf.serve ~stop service in
         let th1 =
@@ -63,6 +63,7 @@ module Make (Time : Mirage_time.S) (Stack : Tcpip.Stack.V4V6) : sig
   }
 
   val request_handler :
+    fallback:(Ipaddr.t * int -> Httpaf.Server_connection.request_handler) option ->
     Ipaddr.t * int -> Httpaf.Server_connection.request_handler
 
   val provision_certificate :

--- a/lib/paf_mirage.ml
+++ b/lib/paf_mirage.ml
@@ -70,7 +70,7 @@ module type S = sig
     t Paf.service
 
   val https_service :
-    tls:Tls.Config.server ->
+    tls:Tls.Config.server ref ->
     ?config:Httpaf.Config.t ->
     error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
     (TLS.flow -> dst -> Httpaf.Server_connection.request_handler) ->
@@ -265,7 +265,7 @@ module Make (Stack : Tcpip.Tcp.S) :
     let module R = (val Mimic.repr tls_protocol) in
     let handshake tcp_flow =
       let dst = TCP.dst tcp_flow in
-      TLS.server_of_flow tls tcp_flow >>= function
+      TLS.server_of_flow !tls tcp_flow >>= function
       | Ok flow -> Lwt.return_ok (dst, flow)
       | Error `Closed ->
           (* XXX(dinosaure): be care! [`Closed] at this stage does not mean

--- a/lib/paf_mirage.mli
+++ b/lib/paf_mirage.mli
@@ -124,7 +124,7 @@ module type S = sig
       service is not yet launched (see {!serve}). *)
 
   val https_service :
-    tls:Tls.Config.server ->
+    tls:Tls.Config.server ref ->
     ?config:Httpaf.Config.t ->
     error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
     (TLS.flow -> dst -> Httpaf.Server_connection.request_handler) ->

--- a/test/simple_server.ml
+++ b/test/simple_server.ml
@@ -164,7 +164,7 @@ let server_https cert key large stack =
   | Ok certs, Ok (`RSA key) ->
       let tls = Tls.Config.server ~certificates:(`Single (certs, `RSA key)) () in
       P.init ~port:4343 stack >>= fun service ->
-      let https = P.https_service ~tls ~error_handler (request_handler large) in
+      let https = P.https_service ~tls:(ref tls) ~error_handler (request_handler large) in
       let (`Initialized th) = P.serve https service in
       unlock fd_4343 ;
       th

--- a/test/test_cohttp.ml
+++ b/test/test_cohttp.ml
@@ -60,7 +60,7 @@ let run_http_and_https_server ~request_handler stop =
   P.init ~port:3434 stack >>= fun socket1 ->
   let http = P.http_service ~error_handler (fun _flow -> request_handler) in
   let https =
-    P.https_service ~tls ~error_handler (fun _flow -> request_handler) in
+    P.https_service ~tls:(ref tls) ~error_handler (fun _flow -> request_handler) in
   let (`Initialized fiber0) = P.serve ~stop http socket0 in
   let (`Initialized fiber1) = P.serve ~stop https socket1 in
   Logs.debug (fun m -> m "Server initialised.") ;


### PR DESCRIPTION
Fixes https://github.com/dinosaure/paf-le-chien/issues/76