### PR TITLE
Be able to specify protocols we want to handle for the let's encrypt higher API

### DIFF
--- a/lib/lE_mirage.ml
+++ b/lib/lE_mirage.ml
@@ -83,7 +83,8 @@ struct
       Alpn.injection;
     }
 
-  let with_lets_encrypt_certificates ?(port = 443) stackv4v6 ~production config
+  let with_lets_encrypt_certificates ?(port = 443)
+      ?(alpn_protocols = [ "h2"; "http/1.1" ]) stackv4v6 ~production config
       handler =
     let certificates = ref None in
     let stop_http_server = Lwt_switch.create () in
@@ -116,9 +117,7 @@ struct
       >>= function
       | None -> Lwt.return_error `No_certificates
       | Some certificates -> (
-          let cfg =
-            Tls.Config.server ~alpn_protocols:[ "h2"; "http/1.1" ] ~certificates
-              () in
+          let cfg = Tls.Config.server ~alpn_protocols ~certificates () in
           Paf.TLS.server_of_flow cfg tcp >>= function
           | Ok flow -> Lwt.return_ok (Paf.TCP.dst tcp, flow)
           | Error `Closed -> Lwt.return_error (`Write `Closed)

--- a/lib/lE_mirage.mli
+++ b/lib/lE_mirage.mli
@@ -23,17 +23,22 @@ module Make
 
   val with_lets_encrypt_certificates :
     ?port:int ->
+    ?alpn_protocols:string list ->
     Stack.t ->
     production:bool ->
     LE.configuration ->
     (Paf.TLS.flow, Ipaddr.t * int) Alpn.server_handler ->
     (unit, [> `Msg of string ]) result Lwt.t
-  (** [with_lets_encrypt_certificates ?port stackv4v6 ~production cfg handler]
+  (** [with_lets_encrypt_certificates ?port ?alpn_protocols stackv4v6 ~production cfg handler]
       launches 2 servers: 1) An HTTP server which handles let's encrypt
-      challenges and redirections 2) An ALPN server (HTTP/1.1 and H2) servers to
-      the user's request handler
+      challenges and redirections 2) An ALPN server (which handles HTTP/1.1 and
+      H2 by default, otherwise you can specify protocols via the [alpn_protocol]
+      argument) which run the user's request handler
 
       Every 80 days, the fiber re-askes a new certificate from let's encrypt and
       re-update the ALPN server with this new certificate. The HTTP server does
-      the redirection to the hostname defined into the given [cfg]. *)
+      the redirection to the hostname defined into the given [cfg].
+
+      {b NOTE}: For the [alpn_protocols] argument, only ["h2"], ["http/1.1"] and
+      ["http/1.0"] are handled. Any others protocols will be {b ignored}! *)
 end


### PR DESCRIPTION
/cc @kit-ty-kate I think the documentation is clear enough about the new optional `alpn_protocol`.