### PR TITLE
H1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.2
+version = 0.27.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters=no

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 0.8.0 (2025-02-17) Paris - France
+
+- Add `x-maintenance-intent` (@hannesm, #100)
+- Remove `mirage-time` dependency and upgrade to mirage-crypto.1.2.0 (@hannesm, #101)
+
 ### 0.7.0 (2024-08-28) Paris - France
 
 - Upgrade to tls.1.0.0 and x509.1.0.0 (@hannesm, #96)

--- a/lib/alpn.ml
+++ b/lib/alpn.ml
@@ -112,7 +112,11 @@ module H1_Client_connection = struct
     (next_read_operation t :> [ `Close | `Read | `Yield | `Upgrade ])
 
   let next_write_operation t =
-    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
+    (next_write_operation t
+      :> [ `Close of int
+         | `Write of Bigstringaf.t H2.IOVec.t list
+         | `Yield
+         | `Upgrade ])
 end
 
 type ('flow, 'edn) info = {
@@ -146,7 +150,11 @@ module H2_Server_connection = struct
   include H2.Server_connection
 
   let next_write_operation t =
-    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
+    (next_write_operation t
+      :> [ `Close of int
+         | `Write of Bigstringaf.t H2.IOVec.t list
+         | `Yield
+         | `Upgrade ])
 end
 
 let service :
@@ -168,10 +176,8 @@ let service :
             respond in
         let request_handler' reqd =
           handler.request flow edn reqd (HTTP_1_1 http_1_1) in
-        let conn =
-          H1.Server_connection.create ~error_handler request_handler' in
-        Lwt.return_ok
-          (flow, Paf.Runtime ((module H1.Server_connection), conn))
+        let conn = H1.Server_connection.create ~error_handler request_handler' in
+        Lwt.return_ok (flow, Paf.Runtime ((module H1.Server_connection), conn))
     | Some "h2" ->
         let edn = info.peer flow in
         let flow = info.injection flow in
@@ -225,7 +231,11 @@ module H2_Client_connection = struct
   include H2.Client_connection
 
   let next_write_operation t =
-    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
+    (next_write_operation t
+      :> [ `Close of int
+         | `Write of Bigstringaf.t H2.IOVec.t list
+         | `Yield
+         | `Upgrade ])
 end
 
 type alpn_response =
@@ -255,8 +265,8 @@ let run ?alpn handler edn request flow =
       let response_handler response body =
         handler.response flow edn response body (HTTP_1_1 http_1_1) in
       let body, conn =
-        H1.Client_connection.request request ~error_handler
-          ~response_handler in
+        H1.Client_connection.request request ~error_handler ~response_handler
+      in
       Lwt.async (fun () -> Paf.run (module H1_Client_connection) conn flow) ;
       Lwt.return_ok (Response_HTTP_1_1 (body, conn))
   | Some protocol, _ ->

--- a/lib/alpn.ml
+++ b/lib/alpn.ml
@@ -28,11 +28,11 @@ end
 
 type http_1_1_protocol =
   (module REQD
-     with type t = Httpaf.Reqd.t
-      and type request = Httpaf.Request.t
-      and type response = Httpaf.Response.t
-      and type Body.ro = [ `read ] Httpaf.Body.t
-      and type Body.wo = [ `write ] Httpaf.Body.t)
+     with type t = H1.Reqd.t
+      and type request = H1.Request.t
+      and type response = H1.Response.t
+      and type Body.ro = H1.Body.Reader.t
+      and type Body.wo = H1.Body.Writer.t)
 
 type h2_protocol =
   (module REQD
@@ -45,12 +45,12 @@ type h2_protocol =
 type ('reqd, 'headers, 'request, 'response, 'ro, 'wo) protocol =
   | HTTP_1_1 :
       http_1_1_protocol
-      -> ( Httpaf.Reqd.t,
-           Httpaf.Headers.t,
-           Httpaf.Request.t,
-           Httpaf.Response.t,
-           [ `read ] Httpaf.Body.t,
-           [ `write ] Httpaf.Body.t )
+      -> ( H1.Reqd.t,
+           H1.Headers.t,
+           H1.Request.t,
+           H1.Response.t,
+           H1.Body.Reader.t,
+           H1.Body.Writer.t )
          protocol
   | H2 :
       h2_protocol
@@ -64,25 +64,25 @@ type ('reqd, 'headers, 'request, 'response, 'ro, 'wo) protocol =
 
 let http_1_1 =
   let module M = struct
-    include Httpaf.Reqd
+    include H1.Reqd
 
-    type request = Httpaf.Request.t
-    type response = Httpaf.Response.t
+    type request = H1.Request.t
+    type response = H1.Response.t
 
     module Body = struct
-      type ro = [ `read ] Httpaf.Body.t
-      type wo = [ `write ] Httpaf.Body.t
+      type ro = H1.Body.Reader.t
+      type wo = H1.Body.Writer.t
     end
 
     let respond_with_streaming t ?flush_headers_immediately response =
       respond_with_streaming t ?flush_headers_immediately response
   end in
   (module M : REQD
-    with type t = Httpaf.Reqd.t
-     and type request = Httpaf.Request.t
-     and type response = Httpaf.Response.t
-     and type Body.ro = [ `read ] Httpaf.Body.t
-     and type Body.wo = [ `write ] Httpaf.Body.t)
+    with type t = H1.Reqd.t
+     and type request = H1.Request.t
+     and type response = H1.Response.t
+     and type Body.ro = H1.Body.Reader.t
+     and type Body.wo = H1.Body.Writer.t)
 
 let h2 =
   let module M = struct
@@ -103,13 +103,16 @@ let h2 =
      and type Body.ro = H2.Body.Reader.t
      and type Body.wo = H2.Body.Writer.t)
 
-module Httpaf_Client_connection = struct
-  include Httpaf.Client_connection
+module H1_Client_connection = struct
+  include H1.Client_connection
 
   let yield_reader _ = assert false
 
   let next_read_operation t =
-    (next_read_operation t :> [ `Close | `Read | `Yield ])
+    (next_read_operation t :> [ `Close | `Read | `Yield | `Upgrade ])
+
+  let next_write_operation t =
+    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
 end
 
 type ('flow, 'edn) info = {
@@ -139,6 +142,13 @@ type ('flow, 'edn) server_handler = {
     unit;
 }
 
+module H2_Server_connection = struct
+  include H2.Server_connection
+
+  let next_write_operation t =
+    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
+end
+
 let service :
     ('flow, 'edn) info ->
     (Mimic.flow, 'edn) server_handler ->
@@ -159,9 +169,9 @@ let service :
         let request_handler' reqd =
           handler.request flow edn reqd (HTTP_1_1 http_1_1) in
         let conn =
-          Httpaf.Server_connection.create ~error_handler request_handler' in
+          H1.Server_connection.create ~error_handler request_handler' in
         Lwt.return_ok
-          (flow, Paf.Runtime ((module Httpaf.Server_connection), conn))
+          (flow, Paf.Runtime ((module H1.Server_connection), conn))
     | Some "h2" ->
         let edn = info.peer flow in
         let flow = info.injection flow in
@@ -170,7 +180,7 @@ let service :
         in
         let request_handler' reqd = handler.request flow edn reqd (H2 h2) in
         let conn = H2.Server_connection.create ~error_handler request_handler' in
-        Lwt.return_ok (flow, Paf.Runtime ((module H2.Server_connection), conn))
+        Lwt.return_ok (flow, Paf.Runtime ((module H2_Server_connection), conn))
     | Some protocol ->
         Lwt.return_error (`Msg (Fmt.str "Invalid protocol %S." protocol)) in
   Paf.service connection connect accept close
@@ -178,7 +188,7 @@ let service :
 type client_error =
   [ `Exn of exn
   | `Malformed_response of string
-  | `Invalid_response_body_length_v1 of Httpaf.Response.t
+  | `Invalid_response_body_length_v1 of H1.Response.t
   | `Invalid_response_body_length_v2 of H2.Response.t
   | `Protocol_error of H2.Error_code.t * string ]
 
@@ -211,9 +221,16 @@ type 'edn client_handler = {
     unit;
 }
 
+module H2_Client_connection = struct
+  include H2.Client_connection
+
+  let next_write_operation t =
+    (next_write_operation t :> [ `Close of int | `Write of Bigstringaf.t H2.IOVec.t list | `Yield | `Upgrade ])
+end
+
 type alpn_response =
   | Response_HTTP_1_1 :
-      ([ `write ] Httpaf.Body.t * Httpaf.Client_connection.t)
+      (H1.Body.Writer.t * H1.Client_connection.t)
       -> alpn_response
   | Response_H2 : H2.Body.Writer.t * H2.Client_connection.t -> alpn_response
 
@@ -230,7 +247,7 @@ let run ?alpn handler edn request flow =
       let body =
         H2.Client_connection.request conn request ~error_handler
           ~response_handler in
-      Lwt.async (fun () -> Paf.run (module H2.Client_connection) conn flow) ;
+      Lwt.async (fun () -> Paf.run (module H2_Client_connection) conn flow) ;
       Lwt.return_ok (Response_H2 (body, conn))
   | (Some "http/1.1" | None), `V1 request ->
       let error_handler error =
@@ -238,9 +255,9 @@ let run ?alpn handler edn request flow =
       let response_handler response body =
         handler.response flow edn response body (HTTP_1_1 http_1_1) in
       let body, conn =
-        Httpaf.Client_connection.request request ~error_handler
+        H1.Client_connection.request request ~error_handler
           ~response_handler in
-      Lwt.async (fun () -> Paf.run (module Httpaf_Client_connection) conn flow) ;
+      Lwt.async (fun () -> Paf.run (module H1_Client_connection) conn flow) ;
       Lwt.return_ok (Response_HTTP_1_1 (body, conn))
   | Some protocol, _ ->
       Lwt.return_error

--- a/lib/dune
+++ b/lib/dune
@@ -8,7 +8,7 @@
  (name alpn)
  (public_name paf.alpn)
  (modules alpn)
- (libraries paf httpaf h2))
+ (libraries paf h1 h2))
 
 (library
  (name paf_mirage)
@@ -20,4 +20,4 @@
  (name paf_cohttp)
  (public_name paf-cohttp)
  (modules paf_cohttp)
- (libraries ipaddr domain-name paf httpaf cohttp-lwt))
+ (libraries ipaddr domain-name paf h1 cohttp-lwt))

--- a/lib/paf.ml
+++ b/lib/paf.ml
@@ -25,7 +25,11 @@ module type RUNTIME = sig
       {!next_read_operation} returns a [`Yield] value. *)
 
   val next_write_operation :
-    t -> [ `Write of Bigstringaf.t Faraday.iovec list | `Yield | `Close of int | `Upgrade ]
+    t ->
+    [ `Write of Bigstringaf.t Faraday.iovec list
+    | `Yield
+    | `Close of int
+    | `Upgrade ]
   (** [next_write_operation t] returns a value describing the next operation
       that the caller should conduct on behalf the connection. *)
 
@@ -55,7 +59,8 @@ module type RUNTIME = sig
   (** [is_closed t] is [true] if both the read and write processors have been
       shutdown. When this is the case {!next_read_operation} will return
       [`Close _] and {!next_write_operation} will return a [`Write _] until all
-      buffered output has been flushed, at which point it will return [`Close]. *)
+      buffered output has been flushed, at which point it will return [`Close].
+  *)
 
   val shutdown : t -> unit
   (** [shutdown t] asks to shutdown the connection. *)
@@ -143,8 +148,7 @@ module Make (Flow : Mirage_flow.S) = struct
     Flow.writev flow.flow iovecs >>= function
     | Ok () ->
         Lwt.return
-          (`Ok
-            (List.fold_left (fun acc cs -> acc + Cstruct.length cs) 0 iovecs))
+          (`Ok (List.fold_left (fun acc cs -> acc + Cstruct.length cs) 0 iovecs))
     | Error err ->
         Log_flow.err (fun m ->
             m "Got an error when we wrote something: %a." Flow.pp_write_error
@@ -343,8 +347,7 @@ let service connection handshake accept close =
 
 open Lwt.Infix
 
-let serve_when_ready :
-    type t socket flow.
+let serve_when_ready : type t socket flow.
     (t, socket, flow, _) posix ->
     ?stop:Lwt_switch.t ->
     handler:(flow -> unit Lwt.t) ->

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -1,7 +1,7 @@
 module type RUNTIME = sig
   type t
 
-  val next_read_operation : t -> [ `Read | `Yield | `Close ]
+  val next_read_operation : t -> [ `Read | `Yield | `Close | `Upgrade ]
   (** [next_read_connection t] returns a value describing the next operation
       that the caller should conduit on behalf of the connection. *)
 
@@ -25,7 +25,7 @@ module type RUNTIME = sig
       {!next_read_operation} returns a [`Yield] value. *)
 
   val next_write_operation :
-    t -> [ `Write of Bigstringaf.t Faraday.iovec list | `Yield | `Close of int ]
+    t -> [ `Write of Bigstringaf.t Faraday.iovec list | `Yield | `Close of int | `Upgrade ]
   (** [next_write_operation t] returns a value describing the next operation
       that the caller should conduct on behalf the connection. *)
 

--- a/lib/paf.mli
+++ b/lib/paf.mli
@@ -25,7 +25,11 @@ module type RUNTIME = sig
       {!next_read_operation} returns a [`Yield] value. *)
 
   val next_write_operation :
-    t -> [ `Write of Bigstringaf.t Faraday.iovec list | `Yield | `Close of int | `Upgrade ]
+    t ->
+    [ `Write of Bigstringaf.t Faraday.iovec list
+    | `Yield
+    | `Close of int
+    | `Upgrade ]
   (** [next_write_operation t] returns a value describing the next operation
       that the caller should conduct on behalf the connection. *)
 
@@ -55,7 +59,8 @@ module type RUNTIME = sig
   (** [is_closed t] is [true] if both the read and write processors have been
       shutdown. When this is the case {!next_read_operation} will return
       [`Close _] and {!next_write_operation} will return a [`Write _] until all
-      buffered output has been flushed, at which point it will return [`Close]. *)
+      buffered output has been flushed, at which point it will return [`Close].
+  *)
 
   val shutdown : t -> unit
 end

--- a/lib/paf_mirage.ml
+++ b/lib/paf_mirage.ml
@@ -69,21 +69,21 @@ module type S = sig
   val close : t -> unit Lwt.t
 
   val http_service :
-    ?config:Httpaf.Config.t ->
-    error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
-    (TCP.flow -> dst -> Httpaf.Server_connection.request_handler) ->
+    ?config:H1.Config.t ->
+    error_handler:(dst -> H1.Server_connection.error_handler) ->
+    (TCP.flow -> dst -> H1.Server_connection.request_handler) ->
     t Paf.service
 
   val https_service :
     tls:Tls.Config.server ->
-    ?config:Httpaf.Config.t ->
-    error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
-    (TLS.flow -> dst -> Httpaf.Server_connection.request_handler) ->
+    ?config:H1.Config.t ->
+    error_handler:(dst -> H1.Server_connection.error_handler) ->
+    (TLS.flow -> dst -> H1.Server_connection.request_handler) ->
     t Paf.service
 
   val alpn_service :
     tls:Tls.Config.server ->
-    ?config:Httpaf.Config.t * H2.Config.t ->
+    ?config:H1.Config.t * H2.Config.t ->
     (TLS.flow, dst) Alpn.server_handler ->
     t Paf.service
 
@@ -265,10 +265,10 @@ module Make (Stack : Tcpip.Tcp.S) :
       let error_handler = error_handler dst in
       let request_handler' reqd = request_handler flow dst reqd in
       let conn =
-        Httpaf.Server_connection.create ?config ~error_handler request_handler'
+        H1.Server_connection.create ?config ~error_handler request_handler'
       in
       Lwt.return_ok
-        (R.T flow, Paf.Runtime ((module Httpaf.Server_connection), conn)) in
+        (R.T flow, Paf.Runtime ((module H1.Server_connection), conn)) in
     Paf.service connection Lwt.return_ok accept close
 
   let https_service ~tls ?config ~error_handler request_handler =
@@ -290,10 +290,10 @@ module Make (Stack : Tcpip.Tcp.S) :
       let error_handler = error_handler dst in
       let request_handler' reqd = request_handler flow dst reqd in
       let conn =
-        Httpaf.Server_connection.create ?config ~error_handler request_handler'
+        H1.Server_connection.create ?config ~error_handler request_handler'
       in
       Lwt.return_ok
-        (R.T flow, Paf.Runtime ((module Httpaf.Server_connection), conn)) in
+        (R.T flow, Paf.Runtime ((module H1.Server_connection), conn)) in
     Paf.service connection handshake accept close
 
   let alpn =
@@ -313,7 +313,7 @@ module Make (Stack : Tcpip.Tcp.S) :
       Alpn.injection;
     }
 
-  let alpn_service ~tls ?config:(_ = (Httpaf.Config.default, H2.Config.default))
+  let alpn_service ~tls ?config:(_ = (H1.Config.default, H2.Config.default))
       handler =
     let handshake tcp_flow =
       let dst = TCP.dst tcp_flow in

--- a/lib/paf_mirage.ml
+++ b/lib/paf_mirage.ml
@@ -267,8 +267,8 @@ module Make (Stack : Tcpip.Tcp.S) :
       let conn =
         H1.Server_connection.create ?config ~error_handler request_handler'
       in
-      Lwt.return_ok
-        (R.T flow, Paf.Runtime ((module H1.Server_connection), conn)) in
+      Lwt.return_ok (R.T flow, Paf.Runtime ((module H1.Server_connection), conn))
+    in
     Paf.service connection Lwt.return_ok accept close
 
   let https_service ~tls ?config ~error_handler request_handler =
@@ -292,8 +292,8 @@ module Make (Stack : Tcpip.Tcp.S) :
       let conn =
         H1.Server_connection.create ?config ~error_handler request_handler'
       in
-      Lwt.return_ok
-        (R.T flow, Paf.Runtime ((module H1.Server_connection), conn)) in
+      Lwt.return_ok (R.T flow, Paf.Runtime ((module H1.Server_connection), conn))
+    in
     Paf.service connection handshake accept close
 
   let alpn =
@@ -336,7 +336,8 @@ module Make (Stack : Tcpip.Tcp.S) :
       | _ -> assert false
       (* XXX(dinosaure): this case should never occur. Indeed, the [injection]
          given to [Alpn.service] only create a [tls_protocol] flow. We just
-         destruct it and give it to [request_handler]. *) in
+         destruct it and give it to [request_handler]. *)
+    in
     Alpn.service alpn { handler with request } handshake accept close
 
   let serve ?stop service t = Paf.serve ?stop service t

--- a/lib/paf_mirage.mli
+++ b/lib/paf_mirage.mli
@@ -120,9 +120,9 @@ module type S = sig
       ]} *)
 
   val http_service :
-    ?config:Httpaf.Config.t ->
-    error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
-    (TCP.flow -> dst -> Httpaf.Server_connection.request_handler) ->
+    ?config:H1.Config.t ->
+    error_handler:(dst -> H1.Server_connection.error_handler) ->
+    (TCP.flow -> dst -> H1.Server_connection.request_handler) ->
     t Paf.service
   (** [http_service ~error_handler request_handler] makes an HTTP/AF service
       where any HTTP/1.1 requests are handled by [request_handler]. The returned
@@ -130,9 +130,9 @@ module type S = sig
 
   val https_service :
     tls:Tls.Config.server ->
-    ?config:Httpaf.Config.t ->
-    error_handler:(dst -> Httpaf.Server_connection.error_handler) ->
-    (TLS.flow -> dst -> Httpaf.Server_connection.request_handler) ->
+    ?config:H1.Config.t ->
+    error_handler:(dst -> H1.Server_connection.error_handler) ->
+    (TLS.flow -> dst -> H1.Server_connection.request_handler) ->
     t Paf.service
   (** [https_service ~tls ~error_handler request_handler] makes an HTTP/AF
       service over TLS (from the given TLS configuration). Then, HTTP/1.1
@@ -152,7 +152,7 @@ module type S = sig
 
   val alpn_service :
     tls:Tls.Config.server ->
-    ?config:Httpaf.Config.t * H2.Config.t ->
+    ?config:H1.Config.t * H2.Config.t ->
     (TLS.flow, dst) Alpn.server_handler ->
     t Paf.service
   (** [alpn_service ~tls handler] makes an H2/HTTP/AF service over TLS (from the
@@ -184,7 +184,7 @@ val paf_transmission : transmission Mimic.value
 val run :
   ctx:Mimic.ctx ->
   (Ipaddr.t * int) option Alpn.client_handler ->
-  [ `V1 of Httpaf.Request.t | `V2 of H2.Request.t ] ->
+  [ `V1 of H1.Request.t | `V2 of H2.Request.t ] ->
   (Alpn.alpn_response, [> Mimic.error ]) result Lwt.t
 (** [run ~ctx handler req] sends an HTTP request (H2 or HTTP/1.1) to a peer
     which can be reached {i via} the given Mimic's [ctx]. If the connection is

--- a/paf-cohttp.opam
+++ b/paf-cohttp.opam
@@ -14,7 +14,7 @@ depends: [
   "paf" {= version}
   "cohttp-lwt" {< "6.0.0~"}
   "domain-name"
-  "httpaf"
+  "h1"
   "ipaddr"
   "alcotest-lwt"      {with-test & >= "1.1.0"}
   "fmt"               {with-test}

--- a/paf.opam
+++ b/paf.opam
@@ -25,7 +25,7 @@ depends: [
   "alcotest-lwt" {with-test}
   "x509" {with-test & > "1.0.0"}
   "bigstringaf" {>= "0.7.0"}
-  "httpaf" {>= "0.7.1"}
+  "h1"
   "h2" {>= "0.10.0"}
   "faraday" {>= "0.7.2"}
   "tls" {>= "1.0.0"}

--- a/test/simple_client.ml
+++ b/test/simple_client.ml
@@ -33,8 +33,7 @@ let ( >>? ) x f =
 let ( <.> ) f g x = f (g x)
 let apply v f = f v
 
-let response_handler :
-    type reqd headers request response ro wo.
+let response_handler : type reqd headers request response ro wo.
     _ ->
     f:(H1.Response.t -> string -> unit Lwt.t) ->
     Mimic.flow ->

--- a/test/test_alpn.ml
+++ b/test/test_alpn.ml
@@ -97,8 +97,7 @@ type version = HTTP_1_1 | HTTP_2_0
 
 let error_handler _ _protocol ?request:_ _error _response = ()
 
-let request_handler :
-    type reqd headers request response ro wo.
+let request_handler : type reqd headers request response ro wo.
     _ ->
     _ ->
     _ ->

--- a/test/test_alpn.ml
+++ b/test/test_alpn.ml
@@ -161,7 +161,7 @@ let test01 =
   let tls =
     Result.get_ok
       (Tls.Config.client ~authenticator ~alpn_protocols:[ "http/1.1" ] ()) in
-  let req = `V1 (Httpaf.Request.create `GET "/") in
+  let req = `V1 (H1.Request.create `GET "/") in
   Lwt.both
     ( unix_stack () >|= Tcpip_stack_socket.V4V6.tcp >>= fun stack ->
       P.init ~port stack >>= fun t ->

--- a/test/test_cohttp.ml
+++ b/test/test_cohttp.ml
@@ -127,14 +127,14 @@ let body_to_string body =
   let th, wk = Lwt.wait () in
   let on_eof () =
     Lwt.wakeup_later wk (Buffer.contents buf) ;
-    Httpaf.Body.close_reader body in
+    H1.Body.Reader.close body in
   let rec on_read str ~off ~len =
     let str = Bigstringaf.substring str ~off ~len in
     Logs.debug (fun m -> m "Received %S." str) ;
     Buffer.add_string buf str ;
-    Httpaf.Body.schedule_read body ~on_eof ~on_read in
+    H1.Body.Reader.schedule_read body ~on_eof ~on_read in
   Logs.debug (fun m -> m "Start to receive the body.") ;
-  Httpaf.Body.schedule_read body ~on_eof ~on_read ;
+  H1.Body.Reader.schedule_read body ~on_eof ~on_read ;
   th
 
 let query_to_assoc str =
@@ -147,7 +147,7 @@ let query_to_assoc str =
   List.map f lst
 
 let request_handler (ip, port) reqd =
-  let open Httpaf in
+  let open H1 in
   let req = Reqd.request reqd in
   Logs.debug (fun m ->
       m "Got a connection from %a:%d %s." Ipaddr.pp ip port req.Request.target) ;


### PR DESCRIPTION
Delay a bit the release to integrate this change. `httpaf` is unmaintained and `h1` (which exists into the robur coop) is updated with several fixes and the ability to make a websocket server (unimplemented).